### PR TITLE
test_smf returns msglen for large message

### DIFF
--- a/src/smf/packet-smf.c
+++ b/src/smf/packet-smf.c
@@ -808,16 +808,6 @@ static guint32 test_smf(tvbuff_t *tvb, packet_info* pinfo, int offset)
         // The message is too big.
         return 1;
     }
-    if ((guint32)remainingLength < msglen)
-    {
-        // Need more data to complete the message
-        if (pinfo->can_desegment) {
-            return 0;
-        } else {
-            // Cannot Desegment from TCP, so just do what we can...
-            return msglen;
-        }
-    }
     
     return msglen;
 }


### PR DESCRIPTION
This is the first part of large message optimization for compression. 
This change also makes large non-compressed smf message decode faster because tcp will not call smf dissection if it does not have a big enough pdu.

Why does the code done like this to begin with?
This is partially my fault. Originally, the code to test smf has two functions, one to just test the header, the other to test AND compute the length. I saw a lot of common code in there and refactor it, but made the above error.