### PR TITLE
Fixes for Wireshark 4.2

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "wireshark"]
 	path = wireshark
 	url = https://gitlab.com/wireshark/wireshark.git
-	branch = wireshark-4.0.5
+	branch = release-4.2

--- a/src/smf/CMakeLists.txt
+++ b/src/smf/CMakeLists.txt
@@ -64,7 +64,7 @@ register_plugin_files(plugin.c
 	${DISSECTOR_SRC}
 )
 
-add_plugin_library(smf epan)
+add_wireshark_plugin_library(smf epan)
 target_include_directories(smf SYSTEM PRIVATE ${ZLIB_INCLUDE_DIRS})
 target_link_libraries(smf epan ${ZLIB_LIBRARIES})
 

--- a/src/smf/packet-assuredctrl.c
+++ b/src/smf/packet-assuredctrl.c
@@ -3167,7 +3167,7 @@ proto_register_assuredctrl(void)
     expert_module_t* expert_assuredctrl = expert_register_protocol(proto_assuredctrl);
     expert_register_field_array(expert_assuredctrl, ei, array_length(ei));
     proto_register_subtree_array(ett, array_length(ett));
-    register_dissector("assuredctrl", dissect_assuredctrl, proto_assuredctrl);
+    register_dissector("solace.assuredctrl", dissect_assuredctrl, proto_assuredctrl);
         
 #if 0
 /* Register preferences module (See Section 2.6 for more on preferences) */

--- a/src/smf/packet-clientctrl.c
+++ b/src/smf/packet-clientctrl.c
@@ -1081,7 +1081,7 @@ proto_register_clientctrl(void)
 	proto_register_field_array(proto_clientctrl, hf, array_length(hf));
 	proto_register_subtree_array(ett, array_length(ett));
 
-    register_dissector("clientctrl", dissect_clientctrl, proto_clientctrl);
+    register_dissector("solace.clientctrl", dissect_clientctrl, proto_clientctrl);
         
 #if 0
 /* Register preferences module (See Section 2.6 for more on preferences) */

--- a/src/smf/packet-matelink.c
+++ b/src/smf/packet-matelink.c
@@ -675,5 +675,5 @@ void proto_register_matelink(void)
     proto_register_field_array(proto_matelink, hf, array_length(hf));
     proto_register_subtree_array(ett, array_length(ett));
 
-    register_dissector("matelink", dissect_matelink, proto_matelink);
+    register_dissector("solace.matelink", dissect_matelink, proto_matelink);
 }

--- a/src/smf/packet-pubctrl.c
+++ b/src/smf/packet-pubctrl.c
@@ -394,7 +394,7 @@ proto_register_pubctrl(void)
 	proto_register_field_array(proto_pubctrl, hf, array_length(hf));
 	proto_register_subtree_array(ett, array_length(ett));
 
-    register_dissector("pubctrl", dissect_pubctrl, proto_pubctrl);
+    register_dissector("solace.pubctrl", dissect_pubctrl, proto_pubctrl);
         
 #if 0
 /* Register preferences module (See Section 2.6 for more on preferences) */

--- a/src/smf/packet-smf-binarymeta.c
+++ b/src/smf/packet-smf-binarymeta.c
@@ -173,7 +173,7 @@ proto_register_bm(void)
 	proto_register_field_array(proto_bm, hf, array_length(hf));
 	proto_register_subtree_array(ett, array_length(ett));
 
-    register_dissector("smf-bm", dissect_bm, proto_bm);
+    register_dissector("solace.smf-bm", dissect_bm, proto_bm);
 
 #if 0
 /* Register preferences module (See Section 2.6 for more on preferences) */

--- a/src/smf/packet-smf-compress.c
+++ b/src/smf/packet-smf-compress.c
@@ -260,7 +260,7 @@ static int dissect_smf_compressed(tvbuff_t *tvb, packet_info *pinfo, proto_tree 
     // Dont care what smf returns, just keep going
     // Could check if we have collect enough data in currentStream_p->desegment_len. To do later...
     // Does not hurt to call smf dissector, just a little slower.
-    call_dissector_only(find_dissector("smf"), next_tvb, pinfo, tree, data);
+    call_dissector_only(find_dissector("solace.smf"), next_tvb, pinfo, tree, data);
 
     if (!PINFO_FD_VISITED(pinfo)) {
         currentStream_p->desegment_offset = pinfo->desegment_offset;
@@ -301,7 +301,7 @@ void proto_register_smf_compress(void)
     };
 
     proto_smf_compressed = proto_register_protocol("Solace Message Format (Compressed)", "SMF-COMP", "smf-comp");
-    register_dissector("smf-comp", dissect_smf_compressed, proto_smf_compressed);
+    register_dissector("solace.smf-comp", dissect_smf_compressed, proto_smf_compressed);
 
     proto_register_field_array(proto_smf_compressed, hf, array_length(hf));
 

--- a/src/smf/packet-smf-openmama-payload.c
+++ b/src/smf/packet-smf-openmama-payload.c
@@ -741,7 +741,7 @@ proto_register_mama_payload(void)
     proto_register_field_array(proto_mama_payload, hf, array_length(hf));
     proto_register_subtree_array(ett, array_length(ett));
 
-    register_dissector("mama-payload", dissect_mama_payload, proto_mama_payload);
+    register_dissector("solace.mama-payload", dissect_mama_payload, proto_mama_payload);
 
 }
 

--- a/src/smf/packet-smf.c
+++ b/src/smf/packet-smf.c
@@ -564,7 +564,7 @@ static void* smf_subdissection_uat_entry_copy_cb(void* dest, const void* orig, s
     return d;
 }
 
-static gboolean smf_subdissection_uat_entry_update_cb(void* record, char** error)
+static bool smf_subdissection_uat_entry_update_cb(void* record, char** error)
 {
     smf_subdissection_uat_entry_t* u = (smf_subdissection_uat_entry_t*)record;
 
@@ -665,7 +665,7 @@ smf_call_subdissector(const smf_subdissection_uat_entry_t* subdissector, tvbuff_
 
 UAT_VS_DEF(smf_subdissection, match_criteria, smf_subdissection_uat_entry_t, smf_subdissection_match_criteria_t, MATCH_CRITERIA_EQUAL, "Equal to")
 UAT_CSTRING_CB_DEF(smf_subdissection, topic_pattern, smf_subdissection_uat_entry_t)
-UAT_PROTO_DEF(smf_subdissection, payload_proto, payload_proto, payload_proto_name, smf_subdissection_uat_entry_t)
+UAT_DISSECTOR_DEF(smf_subdissection, payload_proto, payload_proto, payload_proto_name, smf_subdissection_uat_entry_t)
 UAT_CSTRING_CB_DEF(smf_subdissection, proto_more_info, smf_subdissection_uat_entry_t)
 
 /* reassembly table used for calls into reassemble.h */
@@ -2884,8 +2884,8 @@ void proto_register_smf(void)
     static uat_field_t smf_subdissection_table_columns[] = {
         UAT_FLD_VS(smf_subdissection, match_criteria, "Match criteria", smf_subdissection_match_criteria, "Match criteria"),
         UAT_FLD_CSTRING(smf_subdissection, topic_pattern, "Topic pattern", "Pattern to match for the topic"),
-        UAT_FLD_PROTO(smf_subdissection, payload_proto, "Payload protocol",
-                      "Protocol to be used for the message part of the matching topic"),
+        UAT_FLD_DISSECTOR(smf_subdissection, payload_proto, "Payload dissector",
+                      "Dissector to be used for the message part of the matching topic"),
         UAT_FLD_CSTRING(smf_subdissection, proto_more_info, "Additional Data", "Additional Data to pass to the disector"),
         UAT_END_FIELDS
     };
@@ -2936,11 +2936,11 @@ static int dissect_and_reassemble_smf_over_tls(tvbuff_t* tvb, packet_info* pinfo
     gboolean needMore = TRUE;
     guint32 pduLen;
     tvbuff_t* newTvb;
-    fragment_item* fdHead = NULL;
+    fragment_head* fdHead = NULL;
     gboolean savedFragmented = pinfo->fragmented;
-    fragment_item* fragmentData =
+    fragment_head* fragmentData =
         fragment_get(&smf_gen_reassembly_table, pinfo, id, data);
-    fragment_item* assembledData =
+    fragment_head* assembledData =
         fragment_get_reassembled_id(&smf_gen_reassembly_table, pinfo, id);
 
     // Try load the uat subdissection
@@ -3171,11 +3171,11 @@ static int dissect_smf_bd(tvbuff_t *tvb, packet_info *pinfo, proto_tree *tree, v
     gboolean needMore = TRUE;
     guint32 pduLen;
     tvbuff_t *newTvb;
-    fragment_item *fdHead = NULL;
+    fragment_head *fdHead = NULL;
     gboolean savedFragmented = pinfo->fragmented;
-    fragment_item *fragmentData =
+    fragment_head *fragmentData =
         fragment_get(&reasTable, pinfo, bdChannel, data);
-    fragment_item *assembledData =
+    fragment_head *assembledData =
         fragment_get_reassembled_id(&reasTable, pinfo, bdChannel);
 
     if (bdChannel < 0)

--- a/src/smf/packet-smf.c
+++ b/src/smf/packet-smf.c
@@ -2870,7 +2870,7 @@ void proto_register_smf(void)
     expert_module_t* expert_smf = expert_register_protocol(proto_smf);
     expert_register_field_array(expert_smf, ei, array_length(ei));
 
-    smf_handle = register_dissector("smf", dissect_smf_tcp_pdu, proto_smf);
+    smf_handle = register_dissector("solace.smf", dissect_smf_tcp_pdu, proto_smf);
 
     register_init_routine(&smf_proto_init);
 
@@ -3331,15 +3331,15 @@ void proto_reg_handoff_smf(void)
         heur_dissector_add("tls", dissect_smf_heur_tls, "SMF over TLS/SSL", "smf_tls", proto_smf, (heuristic_enable_e)TRUE);
 
         xml_handle = find_dissector("xml");
-        pubctrl_handle = find_dissector("pubctrl");
-        subctrl_handle = find_dissector("subctrl");
-        xmllink_handle = find_dissector("xmllink");
-        assuredctrl_handle = find_dissector("assuredctrl");
-        smp_handle = find_dissector("smp");
-        smrp_handle = find_dissector("smrp");
-        clientctrl_handle = find_dissector("clientctrl");
-        bm_handle = find_dissector("smf-bm");
-        mama_payload_handle = find_dissector("mama-payload");
+        pubctrl_handle = find_dissector("solace.pubctrl");
+        subctrl_handle = find_dissector("solace.subctrl");
+        xmllink_handle = find_dissector("solace.xmllink");
+        assuredctrl_handle = find_dissector("solace.assuredctrl");
+        smp_handle = find_dissector("solace.smp");
+        smrp_handle = find_dissector("solace.smrp");
+        clientctrl_handle = find_dissector("solace.clientctrl");
+        bm_handle = find_dissector("solace.smf-bm");
+        mama_payload_handle = find_dissector("solace.mama-payload");
         protobuf_handle = find_dissector("protobuf");
         dissector_add_for_decode_as("smf_payload_dissector_table", protobuf_handle);
         smf_reas_init();

--- a/src/smf/packet-smf.h
+++ b/src/smf/packet-smf.h
@@ -22,6 +22,10 @@
 #ifndef __PACKET_SMF_H__
 #define __PACKET_SMF_H__
 
+#include "epan/packet_info.h"
+#include "epan/proto.h"
+#include "epan/tvbuff.h"
+
 struct smfdata {
 	char *subtype;
 };

--- a/src/smf/packet-smp.c
+++ b/src/smf/packet-smp.c
@@ -412,7 +412,7 @@ proto_register_smp(void)
 	proto_register_field_array(proto_smp, hf, array_length(hf));
 	proto_register_subtree_array(ett, array_length(ett));
 
-    register_dissector("smp", dissect_smp, proto_smp);
+    register_dissector("solace.smp", dissect_smp, proto_smp);
         
 #if 0
 /* Register preferences module (See Section 2.6 for more on preferences) */

--- a/src/smf/packet-smrp.c
+++ b/src/smf/packet-smrp.c
@@ -813,7 +813,7 @@ proto_register_smrp(void)
     proto_register_field_array(proto_smrp, hf, array_length(hf));
     proto_register_subtree_array(ett, array_length(ett));
 
-    register_dissector("smrp", dissect_smrp, proto_smrp);
+    register_dissector("solace.smrp", dissect_smrp, proto_smrp);
         
 #if 0
 /* Register preferences module (See Section 2.6 for more on preferences) */

--- a/src/smf/packet-subctrl.c
+++ b/src/smf/packet-subctrl.c
@@ -561,7 +561,7 @@ proto_register_subctrl(void)
 	proto_register_field_array(proto_subctrl, hf, array_length(hf));
 	proto_register_subtree_array(ett, array_length(ett));
 
-    register_dissector("subctrl", dissect_subctrl, proto_subctrl);
+    register_dissector("solace.subctrl", dissect_subctrl, proto_subctrl);
         
 #if 0
 /* Register preferences module (See Section 2.6 for more on preferences) */

--- a/src/smf/packet-xmllink.c
+++ b/src/smf/packet-xmllink.c
@@ -400,7 +400,7 @@ proto_register_xmllink(void)
 	proto_register_field_array(proto_xmllink, hf, array_length(hf));
 	proto_register_subtree_array(ett, array_length(ett));
 
-    register_dissector("xmllink", dissect_xmllink, proto_xmllink);
+    register_dissector("solace.xmllink", dissect_xmllink, proto_xmllink);
         
 #if 0
 /* Register preferences module (See Section 2.6 for more on preferences) */

--- a/src/smf/perftool-decoder.h
+++ b/src/smf/perftool-decoder.h
@@ -26,6 +26,9 @@
 #ifndef PERFTOOL_DECODER_H_
 #define PERFTOOL_DECODER_H_
 
+#include "epan/proto.h"
+#include "epan/tvbuff.h"
+
 void
 add_tooldata_block(proto_tree *bm_tree, int headerFieldIndex, tvbuff_t *tvb, int start_offset, int* length);
 

--- a/src/smf/sdt-decoder.c
+++ b/src/smf/sdt-decoder.c
@@ -431,5 +431,5 @@ add_sdt_block(proto_tree *bm_tree, packet_info* pinfo, int headerFieldIndex, tvb
 void sdt_decoder_init(void) 
 {
     xml_handle = find_dissector("xml");
-    smrp_handle = find_dissector("smrp");
+    smrp_handle = find_dissector("solace.smrp");
 }

--- a/src/smf/sdt-decoder.h
+++ b/src/smf/sdt-decoder.h
@@ -26,7 +26,9 @@
 #ifndef SDT_DECODER_H_
 #define SDT_DECODER_H_
 
-extern gint ett_trace_span_message_creation_context;
+#include "epan/proto.h"
+
+extern int ett_trace_span_message_creation_context;
 
 void
 add_sdt_block(proto_tree *bm_tree, packet_info* pinfo, int headerFieldIndex, tvbuff_t *tvb, int offset, int length, int indent, gboolean is_in_map);


### PR DESCRIPTION
This fixes a few things so that the plugin compiles and runs on Wireshark 4.2.