### PR TITLE
SMF changes to attachment subdissectors

### DIFF
--- a/.github/workflows/build_plugin.yml
+++ b/.github/workflows/build_plugin.yml
@@ -20,25 +20,25 @@ on:
         default: "5"
 jobs:
   build_macos:
-    uses: SolaceLabs/wireshark-smf-plugin/.github/workflows/macos.yml
+    uses: SolaceLabs/wireshark-smf-plugin/.github/workflows/macos.yml@main
     with:
       MAJOR_VERSION: ${{ inputs.MAJOR_VERSION || '4' }}
       MINOR_VERSION: ${{ inputs.MINOR_VERSION || '0' }}
       PATCH_VERSION: ${{ inputs.PATCH_VERSION || '5' }}
   build_macos_arm64:
-    uses: SolaceLabs/wireshark-smf-plugin/.github/workflows/macos_arm64.yml
+    uses: SolaceLabs/wireshark-smf-plugin/.github/workflows/macos_arm64.yml@main
     with:
       MAJOR_VERSION: ${{ inputs.MAJOR_VERSION || '4' }}
       MINOR_VERSION: ${{ inputs.MINOR_VERSION || '0' }}
       PATCH_VERSION: ${{ inputs.PATCH_VERSION || '5' }}
   build_windows:
-    uses: SolaceLabs/wireshark-smf-plugin/.github/workflows/windows.yml
+    uses: SolaceLabs/wireshark-smf-plugin/.github/workflows/windows.yml@main
     with:
       MAJOR_VERSION: ${{ inputs.MAJOR_VERSION || '4' }}
       MINOR_VERSION: ${{ inputs.MINOR_VERSION || '0' }}
       PATCH_VERSION: ${{ inputs.PATCH_VERSION || '5' }}
   build_linux:
-    uses: SolaceLabs/wireshark-smf-plugin/.github/workflows/ubuntu.yml
+    uses: SolaceLabs/wireshark-smf-plugin/.github/workflows/ubuntu.yml@main
     with:
       MAJOR_VERSION: ${{ inputs.MAJOR_VERSION || '4' }}
       MINOR_VERSION: ${{ inputs.MINOR_VERSION || '0' }}

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,5 +1,4 @@
 [submodule "wireshark"]
 	path = wireshark
-	url = https://gitlab.com/amqp-protobuf-dissector/wireshark.git
-	branch = 4.0.5-with-amqp-work
-	ignore = untracked
+	url = https://gitlab.com/wireshark/wireshark.git
+	branch = wireshark-4.0.5

--- a/README.md
+++ b/README.md
@@ -3,15 +3,49 @@
 # Wireshark SMF Plugin
 
 ## Overview
-This project is ...
+This project is a plugin for wireshark that will dissect Solace SMF protocol.
 
-## Getting started quickly
-1. Step 1
-1. Step 2
-1. Step 3
+## Getting Started Quickly
 
-## Documentation
-Details about the what why and how of this project. Either refer to external documentations or document in this repo
+**Note: Wireshark SMF Plugin is currently supported on Wireshark 4.0.x**
+
+1. Install [Wireshark 4.0](https://www.wireshark.org/download.html).
+
+2. Download the corresponding zip file for your platform.
+
+3. Unzip the folder and place the .dll (Windows) or .so (Mac/Linux) file in the Wireshark plugin folder, under `epan`. The plugin folder path varies for each OS.
+
+### Windows Plugin Folder
+Personal Plugin Folder: 
+
+`%APPDATA%\Roaming\Wireshark\plugins\4.0\epan`
+
+Global Plugin Folder: 
+
+`C:\Program Files\Wireshark\plugins\4.0\plugins\epan`
+
+### macOS/Linux Plugin Folder
+Personal Plugin Folder: 
+
+`~/.local/lib/wireshark/plugins/epan`
+
+See [Wireshark Documentation on Plugin Folders](https://www.wireshark.org/docs/wsug_html_chunked/ChPluginFolders.html) for more information on installing plugins. 
+
+### Finding Plugin Folders and Verify Installation
+
+1. Open Wireshark
+2. Navigate to `Help>About Wireshark`
+3. Under the `Folders` tab, you can find the location for global and personal folders
+4. After installing the plugin, verify that the plugin is loaded by searching `smf` under the `Plugins` tab
+
+## Building Manually
+
+TODO
+
+## Version Naming Convention
+As this plugin is designed for use in Wireshark, the MAJOR.MINOR match the Wireshark versions. I.E. SMF Plugin 4.0.x indicates support for all patches of Wireshark 4.0.
+
+The PATCH version of the plugin differentiates versions of the SMF Plugin.  As long as the MAJOR.MINOR of the plugin match the corresponding MAJOR.MINOR Wireshark version, then they are compatible.
 
 ## Resources
 This is not an officially supported Solace product.
@@ -20,7 +54,6 @@ For more information try these resources:
 - Ask the [Solace Community](https://solace.community)
 - The Solace Developer Portal website at: https://solace.dev
 
-
 ## Contributing
 Contributions are encouraged! Please read [CONTRIBUTING.md](CONTRIBUTING.md) for details on our code of conduct, and the process for submitting pull requests to us.
 
@@ -28,10 +61,6 @@ Contributions are encouraged! Please read [CONTRIBUTING.md](CONTRIBUTING.md) for
 See the list of [contributors](https://github.com/SolaceLabs/wireshark-smf-plugin/graphs/contributors) who participated in this project.
 
 ## License
-See the [LICENSE](license.txt) file for details.
-
-## License
-
 Wireshark SMF Plugin is licensed under the GNU GPLv2. See the [LICENSE](license.txt) file for details.
 
 ## Disclaimer

--- a/src/smf/packet-smf.c
+++ b/src/smf/packet-smf.c
@@ -784,9 +784,23 @@ static guint32 test_smf(tvbuff_t *tvb, packet_info* pinfo, int offset)
     }
     // Check protocol
     guint8 secondByte = tvb_get_guint8(tvb, offset+1);
-    if ((secondByte & 0x3f) > SMF_PROTOCOL_MAX)
+    guint8 smfProtocol = secondByte & 0x3f;
+    if (smfProtocol > SMF_PROTOCOL_MAX)
     {
         return 1;
+    }
+    // Detect obsolete protocols 
+    switch (smfProtocol) {
+    case SMF_CSMP:
+    case SMF_PUBMSG:
+    case SMF_XMLLINK:
+    case SMF_WSE:
+    case SMF_SUBCTRL:
+    case SMF_PUBCTRL:
+    case SMF_KEEPALIVE:
+        return 1;
+    default:
+        break;
     }
     guint32 headerlen = tvb_get_ntohl(tvb, offset + 4);
     guint32 msglen = tvb_get_ntohl(tvb, offset + 8);
@@ -807,16 +821,6 @@ static guint32 test_smf(tvbuff_t *tvb, packet_info* pinfo, int offset)
         // msgLen - headerlen is the size of the message body.
         // The message is too big.
         return 1;
-    }
-    if ((guint32)remainingLength < msglen)
-    {
-        // Need more data to complete the message
-        if (pinfo->can_desegment) {
-            return 0;
-        } else {
-            // Cannot Desegment from TCP, so just do what we can...
-            return msglen;
-        }
     }
     
     return msglen;
@@ -863,32 +867,37 @@ static guint get_smf_pdu_len(packet_info* inf, tvbuff_t *tvb, int offset, void *
 }
 
 /* Add a base-64 encoded string to the tree */
-static void smf_proto_add_base64_string(proto_tree *tree, int id, tvbuff_t *tvb,
+static void smf_proto_add_base64_string(proto_tree *tree, packet_info *pinfo, int id, tvbuff_t *tvb,
     int offset, int size)
 {
     char* str;
-    gsize len = size;
    
     str = tvb_get_string_enc(NULL, tvb, offset, size, ENC_ASCII);
-    if (len > 1) {
-        g_base64_decode_inplace(str, &len);
+    if (size > 1) {
+        if (strlen(str) > 1) {
+            gsize len = size; // This is for type conversion, g_base64_decode_inplace wants gsize for len
+            g_base64_decode_inplace(str, &len);
+            str[len] = '\0'; // We now have a base64 decode string, let us null terminate it.
+            size = len;
+        } else {
+            g_print("invalid base64 string found in packet %d, strlen is < 1", pinfo->fd->num);
+        }
     }
-    str[len] = '\0';
     proto_tree_add_string(tree, id, tvb, offset, size, str);
 }
 
 /* Add an SMF username to the tree */
-static void smf_proto_add_username_item(proto_tree *tree, tvbuff_t *tvb,
+static void smf_proto_add_username_item(proto_tree *tree, packet_info *pinfo, tvbuff_t *tvb,
     int offset, int size)
 {
-    smf_proto_add_base64_string(tree, hf_smf_username_param, tvb, offset, size);
+    smf_proto_add_base64_string(tree, pinfo, hf_smf_username_param, tvb, offset, size);
 }
 
 /* Add an SMF password to the tree */
-static void smf_proto_add_password_item(proto_tree *tree, tvbuff_t *tvb,
+static void smf_proto_add_password_item(proto_tree *tree, packet_info *pinfo, tvbuff_t *tvb,
     int offset, int size)
 {
-    smf_proto_add_base64_string(tree, hf_smf_password_param, tvb, offset, size);
+    smf_proto_add_base64_string(tree, pinfo, hf_smf_password_param, tvb, offset, size);
 }
 
 /* Add an SMF response to the tree */
@@ -1240,10 +1249,10 @@ static void add_smf_param(tvbuff_t * tvb, packet_info* pinfo, proto_tree * tree,
             proto_tree_add_item(tree, hf_smf_message_id_param, tvb, offset, size, FALSE);
             break;
         case STANDARD_PARAM_USERNAME:
-            smf_proto_add_username_item(tree, tvb, offset, size);
+            smf_proto_add_username_item(tree, pinfo, tvb, offset, size);
             break;
         case STANDARD_PARAM_PASSWORD:
-            smf_proto_add_password_item(tree, tvb, offset, size);
+            smf_proto_add_password_item(tree, pinfo, tvb, offset, size);
             break;
         case STANDARD_PARAM_RESPONSE:
             smf_proto_add_response_item(tree, tvb, offset, size);


### PR DESCRIPTION
Although the changes has solcache subdissector as a usecase, the approach is more generic for all subdissectors of smf attachments.
The change involves:
1) SMF subdissectors is attempted before the decoding based on attachment type.
2) The smf_subdissection_uat is loaded at dissection time rather than at smf dissector initialization. The reason is that the C dissectors are initialized at a time when the lua plugin dissectors are not yet loaded.