### PR TITLE
Update CI to build on Wireshark 4.2 and Draft Release Automation

### DIFF
--- a/.github/workflows/build_plugin.yml
+++ b/.github/workflows/build_plugin.yml
@@ -8,38 +8,48 @@ on:
     inputs:
       MAJOR_VERSION:
         description: "Version string for wireshark tag needed to build can be v#.#.# or v#.#.#-rc#"
-        required: true
-        default: "4"
+        required: false
+        default: ''
       MINOR_VERSION:
         description: "Minor version of the wireshark tag"
-        required: true
-        default: "0"
+        required: false
+        default: ''
       PATCH_VERSION:
         description: "Patch version of the wireshark tag"
-        required: true
-        default: "5"
+        required: false
+        default: ''
 jobs:
+<<<<<<< HEAD
   build_macos:
     uses: SolaceLabs/wireshark-smf-plugin/.github/workflows/macos.yml@main
     with:
       MAJOR_VERSION: ${{ inputs.MAJOR_VERSION || '4' }}
       MINOR_VERSION: ${{ inputs.MINOR_VERSION || '0' }}
       PATCH_VERSION: ${{ inputs.PATCH_VERSION || '5' }}
+=======
+  # Commenting out intel mac for regular builds as it is currently broken.
+  #build_macos:
+  #  uses: SolaceLabs/wireshark-smf-plugin/.github/workflows/macos.yml@main
+  #  with:
+  #    MAJOR_VERSION: ${{ inputs.MAJOR_VERSION || '4' }}
+  #    MINOR_VERSION: ${{ inputs.MINOR_VERSION || '0' }}
+  #    PATCH_VERSION: ${{ inputs.PATCH_VERSION || '5' }}
+>>>>>>> 071dc07 (Updated CI for Wireshark 4.2.4 and added automation for releases)
   build_macos_arm64:
     uses: SolaceLabs/wireshark-smf-plugin/.github/workflows/macos_arm64.yml@main
     with:
       MAJOR_VERSION: ${{ inputs.MAJOR_VERSION || '4' }}
-      MINOR_VERSION: ${{ inputs.MINOR_VERSION || '0' }}
-      PATCH_VERSION: ${{ inputs.PATCH_VERSION || '5' }}
+      MINOR_VERSION: ${{ inputs.MINOR_VERSION || '2' }}
+      PATCH_VERSION: ${{ inputs.PATCH_VERSION || '4' }}
   build_windows:
     uses: SolaceLabs/wireshark-smf-plugin/.github/workflows/windows.yml@main
     with:
       MAJOR_VERSION: ${{ inputs.MAJOR_VERSION || '4' }}
-      MINOR_VERSION: ${{ inputs.MINOR_VERSION || '0' }}
-      PATCH_VERSION: ${{ inputs.PATCH_VERSION || '5' }}
+      MINOR_VERSION: ${{ inputs.MINOR_VERSION || '2' }}
+      PATCH_VERSION: ${{ inputs.PATCH_VERSION || '4' }}
   build_linux:
     uses: SolaceLabs/wireshark-smf-plugin/.github/workflows/ubuntu.yml@main
     with:
       MAJOR_VERSION: ${{ inputs.MAJOR_VERSION || '4' }}
-      MINOR_VERSION: ${{ inputs.MINOR_VERSION || '0' }}
-      PATCH_VERSION: ${{ inputs.PATCH_VERSION || '5' }}
+      MINOR_VERSION: ${{ inputs.MINOR_VERSION || '2' }}
+      PATCH_VERSION: ${{ inputs.PATCH_VERSION || '4' }}

--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -1,0 +1,71 @@
+name: Create Release
+on:
+  workflow_dispatch:
+    inputs:
+      MAJOR_VERSION:
+        description: "Version string for wireshark tag needed to build can be v#.#.# or v#.#.#-rc#"
+        required: false
+        default: '4'
+      MINOR_VERSION:
+        description: "Minor version of the wireshark tag"
+        required: false
+        default: '2'
+      PATCH_VERSION:
+          description: "Patch version of the wireshark tag"
+          required: false
+          default: '4'
+      RELEASE_PATCH_VERSION:
+        description: "PATCH for SMF plugin"
+        required: true
+        default: ''
+env:
+  LINUX_x86_64_PLUGIN_NAME: wireshark-smf-linux-x86_64.tar.gz
+  WINDOWS_x64_PLUGIN_NAME: wireshark-smf-windows-x64.zip
+  MACOS_ARM64_PLUGIN_NAME: wireshark-smf-macos-arm64.tar.gz
+
+jobs:
+  # TODO: Change NeelPatel-Solace to SolaceLabs
+  build_linux:
+    uses: NeelPatel-Solace/wireshark-smf-plugin/.github/workflows/ubuntu.yml@main
+    with:
+      MAJOR_VERSION: ${{ inputs.MAJOR_VERSION || '4' }}
+      MINOR_VERSION: ${{ inputs.MINOR_VERSION || '2' }}
+      PATCH_VERSION: ${{ inputs.PATCH_VERSION || '4' }}
+  
+  build_windows:
+    uses: NeelPatel-Solace/wireshark-smf-plugin/.github/workflows/windows.yml@main
+    with:
+      MAJOR_VERSION: ${{ inputs.MAJOR_VERSION || '4' }}
+      MINOR_VERSION: ${{ inputs.MINOR_VERSION || '2' }}
+      PATCH_VERSION: ${{ inputs.PATCH_VERSION || '4' }}
+    
+  build_macos:
+    uses: NeelPatel-Solace/wireshark-smf-plugin/.github/workflows/macos_arm64.yml@main
+    with:
+      MAJOR_VERSION: ${{ inputs.MAJOR_VERSION || '4' }}
+      MINOR_VERSION: ${{ inputs.MINOR_VERSION || '2' }}
+      PATCH_VERSION: ${{ inputs.PATCH_VERSION || '4' }}
+      
+  create_release:
+    runs-on: ubuntu-latest
+    # Wait for all jobs to finish before continuing
+    needs: [build_linux, build_windows, build_macos]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      # The only way to share artifacts between workflows is to upload and download them.
+      - name: Download Artifacts
+        uses: actions/download-artifact@v4
+        with:
+            path: ${{ github.workspace }}
+
+      - name: Create Release
+        uses: ncipollo/release-action@v1
+        with:
+            name: "Wireshark SMF Plugin ${{ inputs.MAJOR_VERSION }}.${{ inputs.MINOR_VERSION }}.${{ inputs.RELEASE_PATCH_VERSION }}"
+            tag: "${{ inputs.MAJOR_VERSION }}.${{ inputs.MINOR_VERSION }}.${{ inputs.RELEASE_PATCH_VERSION }}"
+            artifacts: "${{ env.LINUX_x86_64_PLUGIN_NAME }}/*, ${{ env.WINDOWS_x64_PLUGIN_NAME }}/*, ${{ env.MACOS_ARM64_PLUGIN_NAME }}/*"
+            bodyFile: "${{ github.workspace }}/docs/wireshark_smf_${{ inputs.MAJOR_VERSION }}-${{ inputs.MINOR_VERSION }}-x_instructions.md"
+            draft: true
+          

--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -24,23 +24,22 @@ env:
   MACOS_ARM64_PLUGIN_NAME: wireshark-smf-macos-arm64.tar.gz
 
 jobs:
-  # TODO: Change NeelPatel-Solace to SolaceLabs
   build_linux:
-    uses: NeelPatel-Solace/wireshark-smf-plugin/.github/workflows/ubuntu.yml@main
+    uses: SolaceLabs/wireshark-smf-plugin/.github/workflows/ubuntu.yml@main
     with:
       MAJOR_VERSION: ${{ inputs.MAJOR_VERSION || '4' }}
       MINOR_VERSION: ${{ inputs.MINOR_VERSION || '2' }}
       PATCH_VERSION: ${{ inputs.PATCH_VERSION || '4' }}
   
   build_windows:
-    uses: NeelPatel-Solace/wireshark-smf-plugin/.github/workflows/windows.yml@main
+    uses: SolaceLabs/wireshark-smf-plugin/.github/workflows/windows.yml@main
     with:
       MAJOR_VERSION: ${{ inputs.MAJOR_VERSION || '4' }}
       MINOR_VERSION: ${{ inputs.MINOR_VERSION || '2' }}
       PATCH_VERSION: ${{ inputs.PATCH_VERSION || '4' }}
     
   build_macos:
-    uses: NeelPatel-Solace/wireshark-smf-plugin/.github/workflows/macos_arm64.yml@main
+    uses: SolaceLabs/wireshark-smf-plugin/.github/workflows/macos_arm64.yml@main
     with:
       MAJOR_VERSION: ${{ inputs.MAJOR_VERSION || '4' }}
       MINOR_VERSION: ${{ inputs.MINOR_VERSION || '2' }}

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -1,5 +1,7 @@
 name: Build MacOS
-
+# This is a workflow specifically for Intel macOS.
+# This workflow has last been updated to work for Wireshark 4.0.5 and is currently not being used.
+# Modifications to this file will be needed to get it working with later versions of Wireshark.
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/macos_arm64.yml
+++ b/.github/workflows/macos_arm64.yml
@@ -7,23 +7,32 @@ on:
         description: "Version string for wireshark tag needed to build can be v#.#.# or v#.#.#-rc#"
         type: string
         required: true
-        default: "4"
+        default: '4'
       MINOR_VERSION:
         description: "Minor version of the wireshark tag"
         type: string
         required: true
-        default: "0"
+        default: '2'
       PATCH_VERSION:
         description: "Patch version of the wireshark tag"
         type: string
         required: true
-        default: "5"
+        default: '4'
+
+env:
+  # This is the name for the file in releases
+  PLUGIN_NAME: wireshark-smf-macos-arm64.tar.gz
 
 jobs:
   macos:
     name: Build on MacOS
-    runs-on: macos-latest-xlarge
+    runs-on: macos-14
     steps:
+      #- name: Checkout with Submodule
+      #  if: ${{ inputs.MAJOR_VERSION == '' }}
+      #  uses: actions/checkout@v4
+      #  with:
+      #    submodules: recursive
       - name: Checkout
         uses: actions/checkout@v3
       - name: Checkout Wireshark
@@ -32,20 +41,26 @@ jobs:
           repository: wireshark/wireshark
           path: "./wireshark"
           ref: v${{ inputs.MAJOR_VERSION }}.${{ inputs.MINOR_VERSION }}.${{ inputs.PATCH_VERSION }}
+      - name: Checkout with Specified Input
+        if : ${{ inputs.MAJOR_VERSION != '' }}
+        uses: actions/checkout@v4
+        with:
+          repository: wireshark/wireshark
+          path: "./wireshark"
+          ref: v${{ inputs.MAJOR_VERSION }}.${{ inputs.MINOR_VERSION }}.${{ inputs.PATCH_VERSION }}
+
+      - name: Install Xcode
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: latest-stable
+
       - name: Set up Python 3.10
         uses: actions/setup-python@v4
         with:
           python-version: "3.10"
-      - name: Install deps
-        continue-on-error: true
-        run: |
-          brew install opus c-ares glib libgcrypt gnutls lua cmake python nghttp2 snappy lz4 libxml2 ninja \
-            libmaxminddb libsmi spandsp brotli minizip zstd libssh libilbc speexdsp gettext pcre2 "$@"
 
-          # install qt5
-          brew install qt@5
-          qt5_dir="$(brew --prefix)/opt/qt@5/lib/cmake/Qt5:/usr/local/Cellar/qt@5/5.15.12:/usr/local/Cellar/qt@5/5.15.12/lib/cmake/Qt5:/usr/local/opt/qt@5/bin:/opt/homebrew/opt/qt@5"
-          echo "Qt5_DIR=$qt5_dir" >> $GITHUB_ENV
+      - name: Run Setup Script
+        run: ./wireshark/tools/macos-setup-brew.sh
 
       - name: Link SMF plugin
         shell: bash
@@ -58,31 +73,31 @@ jobs:
 
       - name: Cmake
         working-directory: build
-        env:
-          CMAKE_PREFIX_PATH: ${{ env.Qt5_DIR }}
-          Qt5_DIR: ${{ env.Qt5_DIR }}
-          PKG_CONFIG_PATH: ${{ env.Qt5_DIR }}/lib/pkgconfig
+
         run: |
-          cmake -GNinja  ${{ github.workspace }}/wireshark \
-            -D CMAKE_PREFIX_PATH=${{ env.Qt5_DIR }} \
-            -D Qt5_DIR=${{ env.Qt5_DIR }} \
-            -D Qt5Core_DIR=${{ env.Qt5_DIR }} \
-            -D CMAKE_OSX_ARCHITECTURES="arm64" \
-            -DCMAKE_APPLE_SILICON_PROCESSOR=arm64 \
+          cmake -G Ninja ${{ github.workspace }}/wireshark \
             -DCMAKE_OSX_ARCHITECTURES=arm64 \
+            -DCMAKE_APPLE_SILICON_PROCESSOR=arm64 \
+            -DCMAKE_C_FLAGS="-std=c99" \
             -DPython_ROOT_DIR=${{ env.pythonLocation }} \
             -DPython_LIBRARY=${{ env.pythonLocation }}/lib \
             -DPython_INCLUDE_DIR=${{ env.pythonLocation }}/include \
             -DPython_EXECUTABLE=${{ env.pythonLocation }}/bin/python \
-            -DPython_FIND_STRATEGY=LOCATION \
-            -DCMAKE_POLICY_DEFAULT_CMP0094=NEW
-
+            -DPython_FIND_STRATEGY=LOCATION 
+            
       - name: Build
-        run: ninja
         working-directory: build
+        run: ninja
 
+      # A compressed tarball is created for release
+      # This means that the artifact is compressed and zipped as a result.
+      - name: Create Compressed Tarball
+        working-directory: ${{ github.workspace }}/build/run/Wireshark.app/Contents/PlugIns/wireshark
+        run: tar -czvf ${{ github.workspace }}/${{ env.PLUGIN_NAME }} **/epan/smf.so
+      
       - name: Upload Artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: wireshark-smf-macos-arm64
-          path: ${{ github.workspace }}/build/run/Wireshark.app/Contents/PlugIns/wireshark/**/epan/smf.so
+          name: ${{ env.PLUGIN_NAME }}
+          path: "${{ github.workspace }}/${{ env.PLUGIN_NAME }}"
+          overwrite: true

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -7,32 +7,42 @@ on:
         description: "Version string for wireshark tag needed to build can be v#.#.# or v#.#.#-rc#"
         type: string
         required: true
-        default: "4"
+        default: '4'
       MINOR_VERSION:
         description: "Minor version of the wireshark tag"
         type: string
         required: true
-        default: "0"
+        default: '2'
       PATCH_VERSION:
         description: "Patch version of the wireshark tag"
         type: string
         required: true
-        default: "5"
+        default: '4'
+        
+env:
+  # This is the name for the file in releases
+  PLUGIN_NAME: wireshark-smf-linux-x86_64.tar.gz
+
 jobs:
   ubuntu:
     name: Build on Linux
     runs-on: ubuntu-22.04
     steps:
+      #- name: Checkout with Submodule
+      #  if: ${{ inputs.MAJOR_VERSION == '' }}
+      #  uses: actions/checkout@v4
+      #  with:
+      #    submodules: recursive
+
       - name: Checkout
         uses: actions/checkout@v3
-
       - name: Checkout Wireshark
         uses: actions/checkout@v4
         with:
           repository: wireshark/wireshark
           path: "./wireshark"
           ref: v${{ inputs.MAJOR_VERSION }}.${{ inputs.MINOR_VERSION }}.${{ inputs.PATCH_VERSION }}
-
+          
       - name: Install deps
         run: sudo ./wireshark/tools/debian-setup.sh --install-optional --install-test-deps --install-deb-deps python3-pip -y
 
@@ -52,10 +62,16 @@ jobs:
       - name: Build
         run: ninja
         working-directory: build
-
+        
+      # A compressed tarball is created for release
+      # This means that the artifact is compressed and zipped as a result.
+      - name: Create Compressed Tarball
+        working-directory: ${{ github.workspace }}/build/run/plugins
+        run: tar -czvf ${{ github.workspace }}/${{ env.PLUGIN_NAME }} **/epan/smf.so
+        
       - name: Upload Artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: wireshark-smf-linux
-          path: ${{ github.workspace }}/build/run/plugins/**/epan/smf.so
+          name: ${{ env.PLUGIN_NAME }}
+          path: "${{ github.workspace }}/${{ env.PLUGIN_NAME }}"
           overwrite: true

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -7,18 +7,22 @@ on:
         description: "Version string for wireshark tag needed to build can be v#.#.# or v#.#.#-rc#"
         type: string
         required: true
-        default: "4"
+        default: '4'
       MINOR_VERSION:
         description: "Minor version of the wireshark tag"
         type: string
         required: true
-        default: "0"
+        default: '2'
       PATCH_VERSION:
         description: "Patch version of the wireshark tag"
         type: string
         required: true
-        default: "5"
+        default: '4'
 
+env:
+  # This is the name for the file in releases
+  PLUGIN_NAME: wireshark-smf-windows-x64.zip
+  
 jobs:
   windows:
     name: Build on Windows
@@ -29,9 +33,13 @@ jobs:
       CMAKE_PREFIX_PATH: D:\a\wireshark-smf-plugin\Qt\6.2.3\msvc2019_64
       WIRESHARK_VERSION_EXTRA: -GithubActionBuild
     steps:
+      #- name: Checkout with Submodule
+      #  if: ${{ inputs.MAJOR_VERSION == '' }}
+      #  uses: actions/checkout@v4
+      #  with:
+      #    submodules: recursive
       - name: Checkout
         uses: actions/checkout@v3
-
       - name: Checkout Wireshark
         uses: actions/checkout@v4
         with:
@@ -76,7 +84,7 @@ jobs:
 
       - name: Cmake
         run: |
-          cmake -DUSE_qt6=ON -DCMAKE_SYSTEM_VERSION="10.0.20348.0" -A x64 ../wireshark -DCMAKE_POLICY_DEFAULT_CMP0094=NEW -DPythopn3_ROOT_DIR='${{ env.Python3_ROOT_DIR }}' -DPython3_EXECUTABLE='${{ env.Python3_ROOT_DIR }}\python.exe' -DPython3_LIBRARY='${{ env.Python3_ROOT_DIR }}\libs\python380.lib' -DPython3_INCLUDE_DIR='${{ env.Python3_ROOT_DIR }}\Include'
+          cmake -DUSE_qt6=ON -DCMAKE_SYSTEM_VERSION="10.0.20348.0" -A x64 ../wireshark -DCMAKE_POLICY_DEFAULT_CMP0094=NEW -DPython3_ROOT_DIR='${{ env.Python3_ROOT_DIR }}' -DPython3_EXECUTABLE='${{ env.Python3_ROOT_DIR }}\python.exe' -DPython3_LIBRARY='${{ env.Python3_ROOT_DIR }}\libs\python380.lib' -DPython3_INCLUDE_DIR='${{ env.Python3_ROOT_DIR }}\Include'
         env:
           PLATFORM: x64
           WIRESHARK_BASE_DIR: C:/wireshark-libs
@@ -86,9 +94,15 @@ jobs:
       - name: Build
         run: cmake --build . --config RelWithDebInfo
         working-directory: build
+      
+      # A zip is created for release
+      # This means that the artifact is double-zipped as a result
+      - name: Create Zip
+        working-directory: ${{ github.workspace }}/build/run/RelWithDebInfo/plugins
+        run: Compress-Archive ./* -Destination ${{ github.workspace }}\${{ env.PLUGIN_NAME }}
 
       - name: Upload Artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: wireshark-smf-windows
-          path: ${{ github.workspace }}/build/run/RelWithDebInfo/plugins/**/**/smf.dll
+          name: ${{ env.PLUGIN_NAME }}
+          path: ${{ github.workspace }}/${{ env.PLUGIN_NAME }}

--- a/docs/wireshark_smf_4-0-x_instructions.md
+++ b/docs/wireshark_smf_4-0-x_instructions.md
@@ -1,0 +1,32 @@
+**Note: this plugin is only compatible with Wireshark 4.0.x**
+
+## Installation Instructions
+
+1. Install [Wireshark 4.0](https://www.wireshark.org/download.html).
+
+2. Download the corresponding zip file for your platform.
+
+3. Unzip the folder and place the .dll (Windows) or .so (Mac/Linux) file in the Wireshark plugin folder, under `epan`. The plugin folder path varies for each OS.
+
+### Windows Plugin Folder
+Personal Plugin Folder: 
+
+`%APPDATA%\Roaming\Wireshark\plugins\4.0\epan`
+
+Global Plugin Folder: 
+
+`C:\Program Files\Wireshark\plugins\4.0\plugins\epan`
+
+### macOS/Linux Plugin Folder
+Personal Plugin Folder: 
+
+`~/.local/lib/wireshark/plugins/epan`
+
+See [Wireshark Documentation on Plugin Folders](https://www.wireshark.org/docs/wsug_html_chunked/ChPluginFolders.html) for more information on installing plugins. 
+
+## Finding Plugin Folders and Verify Installation
+
+1. Open Wireshark
+2. Navigate to `Help>About Wireshark`
+3. Under the `Folders` tab, you can find the location for global and personal folders
+4. After installing the plugin, verify that the plugin is loaded by searching `smf` under the `Plugins` tab

--- a/docs/wireshark_smf_4-2-x_instructions.md
+++ b/docs/wireshark_smf_4-2-x_instructions.md
@@ -1,0 +1,32 @@
+**Note: this plugin is only compatible with Wireshark 4.2.x**
+
+## Installation Instructions
+
+1. Install [Wireshark 4.2](https://www.wireshark.org/download.html).
+
+2. Download the corresponding zip file for your platform.
+
+3. Unzip the folder and place the .dll (Windows) or .so (Mac/Linux) file in the Wireshark plugin folder, under `epan`. The plugin folder path varies for each OS.
+
+### Windows Plugin Folder
+Personal Plugin Folder: 
+
+`%APPDATA%\Roaming\Wireshark\plugins\4.2\epan`
+
+Global Plugin Folder: 
+
+`C:\Program Files\Wireshark\plugins\4.2\plugins\epan`
+
+### macOS/Linux Plugin Folder
+Personal Plugin Folder: 
+
+`~/.local/lib/wireshark/plugins/epan`
+
+See [Wireshark Documentation on Plugin Folders](https://www.wireshark.org/docs/wsug_html_chunked/ChPluginFolders.html) for more information on installing plugins. 
+
+## Finding Plugin Folders and Verify Installation
+
+1. Open Wireshark
+2. Navigate to `Help>About Wireshark`
+3. Under the `Folders` tab, you can find the location for global and personal folders
+4. After installing the plugin, verify that the plugin is loaded by searching `smf` under the `Plugins` tab


### PR DESCRIPTION
This pull request contains the following additions and changes:
- Commented out build_macos instructions in build_plugin.yml as there is low priority in fixing the builds for them
- Update the macos arm workflow to install qt6 and use the macos-14 runner
- Automation for creating draft releases
