### PR TITLE
Binary Meta data function does not handle snaplen packet capture well

### DIFF
--- a/src/smf/packet-smf.c
+++ b/src/smf/packet-smf.c
@@ -1990,8 +1990,9 @@ static int dissect_smf_common(tvbuff_t* tvb, packet_info* pinfo, proto_tree* tre
             if (param_info.binary_metadata_length > 0)
             {
                 int metadata_start = payload_offset + param_info.binary_metadata_start;
+                gint remaining_len = tvb_reported_length_remaining(tvb, metadata_start);
                 // Check to see still have data to dissect
-                if (tvb_captured_length(tvb) > (guint)metadata_start) {
+                if (remaining_len > (guint)param_info.binary_metadata_length) {
                     next_tvb = tvb_new_subset_length_caplen(tvb,
                         metadata_start,
                         -1,


### PR DESCRIPTION
In Support we do a lot of snaplength packet captures. If a message contains binary metadata and only part of the data is captured in the binary metadata, the function call proto_tree_add_string() in dissect_bm() will fail which is caught by the proto dissector outside smf, which is fine. However, the Info column is all messed up because the smf dissector function deletes the info column and the replaced column information is added after a successful return of the binary metadata dissector.

To avoid this, we could either avoid calling the binary metadata dissector altogether if the binary metadata is not fully available, or protect the proto_tree_add_string() call.

I have chosen a simpler approach by not calling the function if the data is not all there.