### PR TITLE
Fixes for Wireshark 4.4

### DIFF
--- a/.github/workflows/build_plugin.yml
+++ b/.github/workflows/build_plugin.yml
@@ -30,17 +30,17 @@ jobs:
     uses: SolaceLabs/wireshark-smf-plugin/.github/workflows/macos_arm64.yml@main
     with:
       MAJOR_VERSION: ${{ inputs.MAJOR_VERSION || '4' }}
-      MINOR_VERSION: ${{ inputs.MINOR_VERSION || '2' }}
-      PATCH_VERSION: ${{ inputs.PATCH_VERSION || '4' }}
+      MINOR_VERSION: ${{ inputs.MINOR_VERSION || '4' }}
+      PATCH_VERSION: ${{ inputs.PATCH_VERSION || '0' }}
   build_windows:
     uses: SolaceLabs/wireshark-smf-plugin/.github/workflows/windows.yml@main
     with:
       MAJOR_VERSION: ${{ inputs.MAJOR_VERSION || '4' }}
-      MINOR_VERSION: ${{ inputs.MINOR_VERSION || '2' }}
-      PATCH_VERSION: ${{ inputs.PATCH_VERSION || '4' }}
+      MINOR_VERSION: ${{ inputs.MINOR_VERSION || '4' }}
+      PATCH_VERSION: ${{ inputs.PATCH_VERSION || '0' }}
   build_linux:
     uses: SolaceLabs/wireshark-smf-plugin/.github/workflows/ubuntu.yml@main
     with:
       MAJOR_VERSION: ${{ inputs.MAJOR_VERSION || '4' }}
-      MINOR_VERSION: ${{ inputs.MINOR_VERSION || '2' }}
-      PATCH_VERSION: ${{ inputs.PATCH_VERSION || '4' }}
+      MINOR_VERSION: ${{ inputs.MINOR_VERSION || '4' }}
+      PATCH_VERSION: ${{ inputs.PATCH_VERSION || '0' }}

--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -28,22 +28,22 @@ jobs:
     uses: SolaceLabs/wireshark-smf-plugin/.github/workflows/ubuntu.yml@main
     with:
       MAJOR_VERSION: ${{ inputs.MAJOR_VERSION || '4' }}
-      MINOR_VERSION: ${{ inputs.MINOR_VERSION || '2' }}
-      PATCH_VERSION: ${{ inputs.PATCH_VERSION || '4' }}
+      MINOR_VERSION: ${{ inputs.MINOR_VERSION || '4' }}
+      PATCH_VERSION: ${{ inputs.PATCH_VERSION || '0' }}
   
   build_windows:
     uses: SolaceLabs/wireshark-smf-plugin/.github/workflows/windows.yml@main
     with:
       MAJOR_VERSION: ${{ inputs.MAJOR_VERSION || '4' }}
-      MINOR_VERSION: ${{ inputs.MINOR_VERSION || '2' }}
-      PATCH_VERSION: ${{ inputs.PATCH_VERSION || '4' }}
+      MINOR_VERSION: ${{ inputs.MINOR_VERSION || '4' }}
+      PATCH_VERSION: ${{ inputs.PATCH_VERSION || '0' }}
     
   build_macos:
     uses: SolaceLabs/wireshark-smf-plugin/.github/workflows/macos_arm64.yml@main
     with:
       MAJOR_VERSION: ${{ inputs.MAJOR_VERSION || '4' }}
-      MINOR_VERSION: ${{ inputs.MINOR_VERSION || '2' }}
-      PATCH_VERSION: ${{ inputs.PATCH_VERSION || '4' }}
+      MINOR_VERSION: ${{ inputs.MINOR_VERSION || '4' }}
+      PATCH_VERSION: ${{ inputs.PATCH_VERSION || '0' }}
       
   create_release:
     runs-on: ubuntu-latest

--- a/.github/workflows/docs/wireshark_smf_4-4-x_instructions.md
+++ b/.github/workflows/docs/wireshark_smf_4-4-x_instructions.md
@@ -1,0 +1,32 @@
+**Note: this plugin is only compatible with Wireshark 4.4.x**
+
+## Installation Instructions
+
+1. Install [Wireshark 4.4](https://www.wireshark.org/download.html).
+
+2. Download the corresponding zip file for your platform.
+
+3. Unzip the folder and place the .dll (Windows) or .so (Mac/Linux) file in the Wireshark plugin folder, under `epan`. The plugin folder path varies for each OS.
+
+### Windows Plugin Folder
+Personal Plugin Folder: 
+
+`%APPDATA%\Roaming\Wireshark\plugins\4.4\epan`
+
+Global Plugin Folder: 
+
+`C:\Program Files\Wireshark\plugins\4.4\plugins\epan`
+
+### macOS/Linux Plugin Folder
+Personal Plugin Folder: 
+
+`~/.local/lib/wireshark/plugins/epan`
+
+See [Wireshark Documentation on Plugin Folders](https://www.wireshark.org/docs/wsug_html_chunked/ChPluginFolders.html) for more information on installing plugins. 
+
+## Finding Plugin Folders and Verify Installation
+
+1. Open Wireshark
+2. Navigate to `Help>About Wireshark`
+3. Under the `Folders` tab, you can find the location for global and personal folders
+4. After installing the plugin, verify that the plugin is loaded by searching `smf` under the `Plugins` tab

--- a/.github/workflows/macos_arm64.yml
+++ b/.github/workflows/macos_arm64.yml
@@ -12,12 +12,12 @@ on:
         description: "Minor version of the wireshark tag"
         type: string
         required: true
-        default: '2'
+        default: '4'
       PATCH_VERSION:
         description: "Patch version of the wireshark tag"
         type: string
         required: true
-        default: '4'
+        default: '0'
 
 env:
   # This is the name for the file in releases

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -12,12 +12,12 @@ on:
         description: "Minor version of the wireshark tag"
         type: string
         required: true
-        default: '2'
+        default: '4'
       PATCH_VERSION:
         description: "Patch version of the wireshark tag"
         type: string
         required: true
-        default: '4'
+        default: '0'
         
 env:
   # This is the name for the file in releases

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -12,12 +12,12 @@ on:
         description: "Minor version of the wireshark tag"
         type: string
         required: true
-        default: '2'
+        default: '4'
       PATCH_VERSION:
         description: "Patch version of the wireshark tag"
         type: string
         required: true
-        default: '4'
+        default: '0'
 
 env:
   # This is the name for the file in releases

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "wireshark"]
 	path = wireshark
 	url = https://gitlab.com/wireshark/wireshark.git
-	branch = release-4.2
+	branch = release-4.4

--- a/src/smf/packet-assuredctrl.c
+++ b/src/smf/packet-assuredctrl.c
@@ -30,8 +30,6 @@
 #include <string.h>
 #include <time.h>
 
-#include <glib.h>
-
 #include <epan/packet.h>
 #include <epan/prefs.h>
 
@@ -205,42 +203,42 @@ static int hf_assuredctrl_redelivery_delay_config_rfu = -1;
 static expert_field ei_assuredctrl_smf_expert_transport_window_zero = EI_INIT;
 
 /* Global sample preference ("controls" display of numbers) */
-// static gboolean gPREF_HEX = FALSE;
+// static bool gPREF_HEX = false;
 
 /* Initialize the subtree pointers */
-static gint ett_assuredctrl                         = -1;
-static gint ett_FD_suback_list                      = -1;
-static gint ett_FD_puback_list                      = -1;
-static gint ett_FD_pubnotify_list                   = -1;
-static gint ett_EP_behaviour_list                   = -1;
-static gint ett_XA_msg_openXaSessionRequest_list    = -1;
-static gint ett_XA_msg_openXaSessionResponse_list   = -1;
-static gint ett_XA_msg_resumeXaSessionRequest_list  = -1;
-static gint ett_XA_msg_resumeXaSessionResponse_list = -1;
-static gint ett_XA_msg_closeXaSessionRequest_list   = -1;
-static gint ett_XA_msg_closeXaSessionResponse_list  = -1;
-static gint ett_XA_msg_xaResponse_list              = -1;
-static gint ett_XA_msg_xaStartRequest_list          = -1;
-static gint ett_XA_msg_xaEndRequest_list            = -1;
-static gint ett_XA_msg_xaPrepareRequest_list        = -1;
-static gint ett_XA_msg_xaCommitRequest_list         = -1;
-static gint ett_XA_msg_xaRollbackRequest_list       = -1;
-static gint ett_XA_msg_xaForgetRequest_list         = -1;
-static gint ett_XA_msg_xaRecoverRequest_list        = -1;
-static gint ett_XA_msg_xaRecoverResponse_list       = -1;
+static int ett_assuredctrl                         = -1;
+static int ett_FD_suback_list                      = -1;
+static int ett_FD_puback_list                      = -1;
+static int ett_FD_pubnotify_list                   = -1;
+static int ett_EP_behaviour_list                   = -1;
+static int ett_XA_msg_openXaSessionRequest_list    = -1;
+static int ett_XA_msg_openXaSessionResponse_list   = -1;
+static int ett_XA_msg_resumeXaSessionRequest_list  = -1;
+static int ett_XA_msg_resumeXaSessionResponse_list = -1;
+static int ett_XA_msg_closeXaSessionRequest_list   = -1;
+static int ett_XA_msg_closeXaSessionResponse_list  = -1;
+static int ett_XA_msg_xaResponse_list              = -1;
+static int ett_XA_msg_xaStartRequest_list          = -1;
+static int ett_XA_msg_xaEndRequest_list            = -1;
+static int ett_XA_msg_xaPrepareRequest_list        = -1;
+static int ett_XA_msg_xaCommitRequest_list         = -1;
+static int ett_XA_msg_xaRollbackRequest_list       = -1;
+static int ett_XA_msg_xaForgetRequest_list         = -1;
+static int ett_XA_msg_xaRecoverRequest_list        = -1;
+static int ett_XA_msg_xaRecoverResponse_list       = -1;
 
-static gint ett_TXN_msg_txnResponse_list            = -1;
-static gint ett_TXN_msg_syncPrepareRequest_list     = -1;
-static gint ett_TXN_msg_asyncCommitRequest_list     = -1;
-static gint ett_TXN_msg_syncCommitRequest_list      = -1;
-static gint ett_TXN_msg_syncCommitStart_list        = -1;
-static gint ett_TXN_msg_syncCommitEnd_list          = -1;
-static gint ett_TXN_msg_syncRespoolRequest_list     = -1;
-static gint ett_TXN_msg_asyncRollbackRequest_list   = -1;
-static gint ett_TXN_msg_syncUncommitRequest_list    = -1;
+static int ett_TXN_msg_txnResponse_list            = -1;
+static int ett_TXN_msg_syncPrepareRequest_list     = -1;
+static int ett_TXN_msg_asyncCommitRequest_list     = -1;
+static int ett_TXN_msg_syncCommitRequest_list      = -1;
+static int ett_TXN_msg_syncCommitStart_list        = -1;
+static int ett_TXN_msg_syncCommitEnd_list          = -1;
+static int ett_TXN_msg_syncRespoolRequest_list     = -1;
+static int ett_TXN_msg_asyncRollbackRequest_list   = -1;
+static int ett_TXN_msg_syncUncommitRequest_list    = -1;
 
-static gint ett_assuredctrl_start_replay_param      = -1;
-static gint ett_assuredctrl_timestamp_param = -1;
+static int ett_assuredctrl_start_replay_param      = -1;
+static int ett_assuredctrl_timestamp_param = -1;
 
 #define ASSUREDCTRL_LAST_MSGID_SENT_PARAM   0x01
 #define ASSUREDCTRL_LAST_MSGID_ACKED_PARAM  0x02
@@ -599,7 +597,7 @@ static const value_string app_ack_outcome_names[] = {
 };
 
 /* ---------- Custom Format Fields Functions ----------- */
-static void redelivery_delay_back_off_multiplier_format(gchar* s, guint16 v)
+static void redelivery_delay_back_off_multiplier_format(gchar* s, uint16_t v)
 {
     g_snprintf(s, ITEM_LABEL_LENGTH, "%u (%.2f)", v, (float)v / 100.f);
 }
@@ -611,7 +609,7 @@ static int get_8_bit_value (
     int offset,
     char const * const field_name)
 {
-    guint8 value = tvb_get_guint8(tvb, offset);                 /* gets value of the 8-bit field */
+    uint8_t value = tvb_get_uint8(tvb, offset);                 /* gets value of the 8-bit field */
     proto_tree_add_string_format(                               /* adds formatted string to proto tree*/
         tree, hf_assuredctrl_8_bit_field, tvb, offset, 1, NULL, "%s: %d", field_name, value
     );
@@ -624,7 +622,7 @@ static int get_16_bit_value (
     int offset,
     char const * const field_name)
 {
-    guint16 value = tvb_get_ntohs(tvb, offset);                 /* gets value of the 16-bit field */
+    uint16_t value = tvb_get_ntohs(tvb, offset);                 /* gets value of the 16-bit field */
     proto_tree_add_string_format(                               /* adds formatted string to proto tree*/
         tree, hf_assuredctrl_16_bit_field, tvb, offset, 2, NULL, "%s: %d", field_name, value
     );
@@ -637,7 +635,7 @@ static int get_32_bit_value (
     int offset,
     char const * const field_name)
 {
-    guint32 value = tvb_get_ntohl(tvb, offset);                 /* gets value of the 32-bit field */
+    uint32_t value = tvb_get_ntohl(tvb, offset);                 /* gets value of the 32-bit field */
     proto_tree_add_string_format(                               /* adds formatted string to proto tree*/
         tree, hf_assuredctrl_32_bit_field, tvb, offset, 4, NULL, "%s: %d", field_name, value
     );
@@ -650,7 +648,7 @@ static int get_64_bit_value (
     int offset,
     char const * const field_name)
 {
-    guint64 value = tvb_get_ntoh64(tvb, offset);                /* gets value of the 64-bit field */
+    uint64_t value = tvb_get_ntoh64(tvb, offset);                /* gets value of the 64-bit field */
     proto_tree_add_string_format(                               /* adds formatted string to proto tree*/
         tree, hf_assuredctrl_64_bit_field, tvb, offset, 8, NULL, "%s: %" G_GUINT64_FORMAT, field_name, value
     );
@@ -663,10 +661,10 @@ static int add_assuredCtrl_xaSessionName_item (
     tvbuff_t *tvb, 
     int offset)
 {
-    guint8 nameLen = 0;
+    uint8_t nameLen = 0;
     char sessionName[200];
     
-    nameLen = tvb_get_guint8(tvb, offset++);
+    nameLen = tvb_get_uint8(tvb, offset++);
     tvb_memcpy(tvb, sessionName, offset, nameLen-1);
     proto_tree_add_string_format(tree,
         hf_assuredctrl_xamsg_type_transacted_session_name,
@@ -685,7 +683,7 @@ static void add_assuredCtrl_xaResponse_item (
     proto_item* item;
 
     item = proto_tree_add_item(tree, 
-        hf_assuredctrl_xamsg_type_xaResponse, tvb, offset, size, FALSE);
+        hf_assuredctrl_xamsg_type_xaResponse, tvb, offset, size, false);
 
     sub_tree = proto_item_add_subtree(item, ett_XA_msg_xaResponse_list);
     offset +=1;
@@ -694,16 +692,16 @@ static void add_assuredCtrl_xaResponse_item (
     offset += 2;
 
     proto_tree_add_item(sub_tree, 
-        hf_assuredctrl_xaResponseAction, tvb, offset, 1, FALSE);
+        hf_assuredctrl_xaResponseAction, tvb, offset, 1, false);
 
     proto_tree_add_item(sub_tree, 
-        hf_assuredctrl_xaResponseLogLevel, tvb, offset++, 1, FALSE);
+        hf_assuredctrl_xaResponseLogLevel, tvb, offset++, 1, false);
 
     proto_tree_add_item(sub_tree, 
-        hf_assuredctrl_xaResponseCode, tvb, offset++, 1, FALSE);
+        hf_assuredctrl_xaResponseCode, tvb, offset++, 1, false);
 
     proto_tree_add_item(sub_tree, 
-        hf_assuredctrl_xaResponseSubcode, tvb, offset, 4, FALSE);
+        hf_assuredctrl_xaResponseSubcode, tvb, offset, 4, false);
 
     // I'm assuming this skips forward 4 bytes for the LastPublishedAckMsgId
     // which is no longer in the specifications
@@ -716,26 +714,26 @@ static int add_assuredCtrl_Xid_item (
     tvbuff_t *tvb, 
     int offset)
 {
-    guint8 txnIdSize = 0;
-    guint8 bQualSize = 0;
+    uint8_t txnIdSize = 0;
+    uint8_t bQualSize = 0;
     int old_offset = offset;
 
     offset += get_32_bit_value(tree, tvb, offset, "FormatId");
 
-    txnIdSize = tvb_get_guint8(tvb, offset);
+    txnIdSize = tvb_get_uint8(tvb, offset);
     offset += get_8_bit_value(tree, tvb, offset, "TransactionIdSize");
 
-    bQualSize = tvb_get_guint8(tvb, offset);
+    bQualSize = tvb_get_uint8(tvb, offset);
     offset += get_8_bit_value(tree, tvb, offset, "BranchQualifierSize");
 
     if (txnIdSize != 0) {
         proto_tree_add_item(tree, 
-            hf_assuredctrl_payload_transactionId, tvb, offset, txnIdSize, FALSE);
+            hf_assuredctrl_payload_transactionId, tvb, offset, txnIdSize, false);
         offset += txnIdSize;
     }
     if (bQualSize != 0) {
          proto_tree_add_item(tree, 
-            hf_assuredctrl_payload_branchQualifier, tvb, offset, bQualSize, FALSE);
+            hf_assuredctrl_payload_branchQualifier, tvb, offset, bQualSize, false);
         offset += bQualSize;
     }
     return offset - old_offset;
@@ -751,7 +749,7 @@ static void add_assuredCtrl_openXaSessionRequest_item (
     proto_item* item;
 
     item = proto_tree_add_item(tree, 
-        hf_assuredctrl_xamsg_type_openXaSessionRequest, tvb, offset, size, FALSE);
+        hf_assuredctrl_xamsg_type_openXaSessionRequest, tvb, offset, size, false);
 
     sub_tree = proto_item_add_subtree(item, ett_XA_msg_openXaSessionRequest_list);
     offset++;
@@ -768,7 +766,7 @@ static void add_assuredCtrl_openXaSessionResponse_item (
     proto_item* item;
 
     item = proto_tree_add_item(tree, 
-        hf_assuredctrl_xamsg_type_openXaSessionResponse, tvb, offset, size, FALSE);
+        hf_assuredctrl_xamsg_type_openXaSessionResponse, tvb, offset, size, false);
 
     sub_tree = proto_item_add_subtree(item, ett_XA_msg_openXaSessionResponse_list);
     offset++;
@@ -786,7 +784,7 @@ static void add_assuredCtrl_resumeXaSessionRequest_item (
     proto_item* item;
 
     item = proto_tree_add_item(tree, 
-         hf_assuredctrl_xamsg_type_resumeXaSessionRequest, tvb, offset, size, FALSE);
+         hf_assuredctrl_xamsg_type_resumeXaSessionRequest, tvb, offset, size, false);
 
     sub_tree = proto_item_add_subtree(item, ett_XA_msg_resumeXaSessionRequest_list);
     offset++;
@@ -804,7 +802,7 @@ static void add_assuredCtrl_resumeXaSessionResponse_item (
     proto_item* item;
 
     item = proto_tree_add_item(tree, 
-        hf_assuredctrl_xamsg_type_resumeXaSessionResponse, tvb, offset, size, FALSE);
+        hf_assuredctrl_xamsg_type_resumeXaSessionResponse, tvb, offset, size, false);
 
     sub_tree = proto_item_add_subtree(item, ett_XA_msg_resumeXaSessionResponse_list);
     offset++;
@@ -820,16 +818,16 @@ static void add_assuredCtrl_closeXaSessionRequest_item (
 {
     proto_tree* sub_tree;
     proto_item* item;
-    guint8 nameLen =0;
+    uint8_t nameLen =0;
     char  sessionName[200];
 
     item = proto_tree_add_item(tree, 
-         hf_assuredctrl_xamsg_type_closeXaSessionRequest, tvb, offset, size, FALSE);
+         hf_assuredctrl_xamsg_type_closeXaSessionRequest, tvb, offset, size, false);
 
     sub_tree = proto_item_add_subtree(item, ett_XA_msg_closeXaSessionRequest_list);
     offset++;
 
-    nameLen = tvb_get_guint8(tvb, offset++);
+    nameLen = tvb_get_uint8(tvb, offset++);
     tvb_memcpy(tvb, sessionName, offset, nameLen-1);
 
     proto_tree_add_string_format(sub_tree,
@@ -844,14 +842,14 @@ static void add_assuredCtrl_closeXaSessionResponse_item (
     int size)
 {
 
-    proto_tree_add_item(tree, hf_assuredctrl_xamsg_type_closeXaSessionResponse, tvb, offset, size, FALSE);
+    proto_tree_add_item(tree, hf_assuredctrl_xamsg_type_closeXaSessionResponse, tvb, offset, size, false);
                
 
     /* // Below is old code that doesn't make any sense but I left it in case for some reason it was needed at a later point
     proto_item* item;
 
     item = proto_tree_add_item(tree, 
-        hf_assuredctrl_xamsg_type_closeXaSessionResponse, tvb, offset, size, FALSE);
+        hf_assuredctrl_xamsg_type_closeXaSessionResponse, tvb, offset, size, false);
         */
 
 }
@@ -862,14 +860,14 @@ static void add_assuredCtrl_consumedMsgList_item (
     int offset,
     int *itemSize)
 {
-    guint16 numMsgIds = 0;
-    guint64 msgId = 0;
+    uint16_t numMsgIds = 0;
+    uint64_t msgId = 0;
     int loop =0;
 
     *itemSize = 0;
 
     proto_tree_add_item(tree, 
-            hf_assuredctrl_EndpointId_param, tvb, offset, 4, FALSE);
+            hf_assuredctrl_EndpointId_param, tvb, offset, 4, false);
     offset += 4;
     *itemSize +=4;
 
@@ -897,13 +895,13 @@ static void add_assuredCtrl_xaStartRequest_item (
     proto_item* item;
 
     item = proto_tree_add_item(tree, 
-        hf_assuredctrl_xamsg_type_xaStartRequest, tvb, offset, size, FALSE);
+        hf_assuredctrl_xamsg_type_xaStartRequest, tvb, offset, size, false);
 
     sub_tree = proto_item_add_subtree(item, ett_XA_msg_xaStartRequest_list);
     offset++;
 
     proto_tree_add_item(sub_tree, 
-        hf_assuredctrl_xaStartRequestFlags_byte, tvb, offset++, 1, FALSE);
+        hf_assuredctrl_xaStartRequestFlags_byte, tvb, offset++, 1, false);
 
     offset += get_32_bit_value(sub_tree, tvb, offset, "TransactedSessionId");
     offset += get_32_bit_value(sub_tree, tvb, offset, "Transaction Timeout");
@@ -920,17 +918,17 @@ static void add_assuredCtrl_xaEndRequest_item (
     proto_tree* sub_tree;
     proto_item* item;
     int   loop =0;
-    guint16 numMsgLists = 0;
+    uint16_t numMsgLists = 0;
     int  listSize = 0;
 
     item = proto_tree_add_item(tree, 
-        hf_assuredctrl_xamsg_type_xaEndRequest, tvb, offset, size, FALSE);
+        hf_assuredctrl_xamsg_type_xaEndRequest, tvb, offset, size, false);
 
     sub_tree = proto_item_add_subtree(item, ett_XA_msg_xaEndRequest_list);
     offset++;
 
     proto_tree_add_item(sub_tree, 
-        hf_assuredctrl_xaEndRequestFlags_byte, tvb, offset++, 1, FALSE);
+        hf_assuredctrl_xaEndRequestFlags_byte, tvb, offset++, 1, false);
 
     offset += get_32_bit_value(sub_tree, tvb, offset, "RequestorTransactedSessionId");
     offset += add_assuredCtrl_Xid_item(sub_tree,  tvb, offset);
@@ -955,7 +953,7 @@ static void add_assuredCtrl_xaPrepareRequest_item (
     proto_item* item;
 
     item = proto_tree_add_item(tree, 
-        hf_assuredctrl_xamsg_type_xaPrepareRequest, tvb, offset, size, FALSE);
+        hf_assuredctrl_xamsg_type_xaPrepareRequest, tvb, offset, size, false);
 
     sub_tree = proto_item_add_subtree(item, ett_XA_msg_xaPrepareRequest_list);
     offset++;
@@ -977,13 +975,13 @@ static void add_assuredCtrl_xaCommitRequest_item (
     proto_item* item;
 
     item = proto_tree_add_item(tree, 
-        hf_assuredctrl_xamsg_type_xaCommitRequest, tvb, offset, size, FALSE);
+        hf_assuredctrl_xamsg_type_xaCommitRequest, tvb, offset, size, false);
 
     sub_tree = proto_item_add_subtree(item, ett_XA_msg_xaCommitRequest_list);
     offset++;
 
     proto_tree_add_item(sub_tree, 
-        hf_assuredctrl_xaCommitRequestFlags_byte, tvb, offset++, 1, FALSE);
+        hf_assuredctrl_xaCommitRequestFlags_byte, tvb, offset++, 1, false);
     offset += get_32_bit_value(sub_tree, tvb, offset, "TransactedSessionId");
 
     offset += add_assuredCtrl_Xid_item(sub_tree,  tvb, offset);
@@ -999,7 +997,7 @@ static void add_assuredCtrl_xaRollbackRequest_item (
     proto_item* item;
 
     item = proto_tree_add_item(tree, 
-        hf_assuredctrl_xamsg_type_xaRollbackRequest, tvb, offset, size, FALSE);
+        hf_assuredctrl_xamsg_type_xaRollbackRequest, tvb, offset, size, false);
 
     sub_tree = proto_item_add_subtree(item, ett_XA_msg_xaRollbackRequest_list);
     offset++;
@@ -1021,7 +1019,7 @@ static void add_assuredCtrl_xaForgetRequest_item (
     proto_item* item;
 
     item = proto_tree_add_item(tree, 
-        hf_assuredctrl_xamsg_type_xaForgetRequest, tvb, offset, size, FALSE);
+        hf_assuredctrl_xamsg_type_xaForgetRequest, tvb, offset, size, false);
 
     sub_tree = proto_item_add_subtree(item, ett_XA_msg_xaForgetRequest_list);
     offset++;
@@ -1041,27 +1039,27 @@ static void add_assuredCtrl_xaRecoverRequest_item (
 {
     proto_tree* sub_tree;
     proto_item* item;
-    guint8 flags = 0;
-    guint32 scanCursorLen =0;
+    uint8_t flags = 0;
+    uint32_t scanCursorLen =0;
 
 
     item = proto_tree_add_item(tree, 
-        hf_assuredctrl_xamsg_type_xaRecoverRequest, tvb, offset, size, FALSE);
+        hf_assuredctrl_xamsg_type_xaRecoverRequest, tvb, offset, size, false);
 
     sub_tree = proto_item_add_subtree(item, ett_XA_msg_xaRecoverRequest_list);
     offset++;
 
-    flags = tvb_get_guint8(tvb, offset);
+    flags = tvb_get_uint8(tvb, offset);
 
     proto_tree_add_item(sub_tree, 
-    hf_assuredctrl_xaRecoverRequestFlags_byte, tvb, offset++, 1, FALSE);
+    hf_assuredctrl_xaRecoverRequestFlags_byte, tvb, offset++, 1, false);
 
     offset += get_32_bit_value(sub_tree, tvb, offset, "MaxNumIDs");
 
     if (flags & 0x01) {
         offset += get_32_bit_value(sub_tree, tvb, offset, "ScanCursorLength");
         proto_tree_add_item(sub_tree, 
-            hf_assuredctrl_scanCursorData, tvb, offset++, scanCursorLen, FALSE);
+            hf_assuredctrl_scanCursorData, tvb, offset++, scanCursorLen, false);
     }
 }
 
@@ -1073,35 +1071,35 @@ static void add_assuredCtrl_xaRecoverResponse_item (
 {
     proto_tree* sub_tree;
     proto_item* item;
-    guint32 numXids = 0;
-    guint8 flags = 0;
-    guint32 scanCursorLen =0;
-    guint32 loop = 0;
+    uint32_t numXids = 0;
+    uint8_t flags = 0;
+    uint32_t scanCursorLen =0;
+    uint32_t loop = 0;
 
     item = proto_tree_add_item(tree, 
-        hf_assuredctrl_xamsg_type_xaRecoverResponse, tvb, offset, size, FALSE);
+        hf_assuredctrl_xamsg_type_xaRecoverResponse, tvb, offset, size, false);
 
     sub_tree = proto_item_add_subtree(item, ett_XA_msg_xaRecoverResponse_list);
     offset++;
 
-    flags = tvb_get_guint8(tvb, offset);
+    flags = tvb_get_uint8(tvb, offset);
     proto_tree_add_item(sub_tree, 
-        hf_assuredctrl_xaRecoverResponseFlags_byte, tvb, offset++, 1, FALSE);
+        hf_assuredctrl_xaRecoverResponseFlags_byte, tvb, offset++, 1, false);
 
     /* skip the first 2 bytes of XaResponse*/
     offset +=2;
 
     proto_tree_add_item(sub_tree, 
-         hf_assuredctrl_xaResponseAction, tvb, offset, 1, FALSE);
+         hf_assuredctrl_xaResponseAction, tvb, offset, 1, false);
 
     proto_tree_add_item(sub_tree, 
-        hf_assuredctrl_xaResponseLogLevel, tvb, offset++, 1, FALSE);
+        hf_assuredctrl_xaResponseLogLevel, tvb, offset++, 1, false);
 
     proto_tree_add_item(sub_tree, 
-         hf_assuredctrl_xaResponseCode, tvb, offset++, 1, FALSE);
+         hf_assuredctrl_xaResponseCode, tvb, offset++, 1, false);
 
     proto_tree_add_item(sub_tree, 
-        hf_assuredctrl_xaResponseSubcode, tvb, offset, 4, FALSE);
+        hf_assuredctrl_xaResponseSubcode, tvb, offset, 4, false);
 
     offset += 4;
 
@@ -1109,7 +1107,7 @@ static void add_assuredCtrl_xaRecoverResponse_item (
         scanCursorLen = tvb_get_ntohl(tvb, offset);
         offset += get_32_bit_value(sub_tree, tvb, offset, "ScanCursorLength");
         proto_tree_add_item(sub_tree, 
-            hf_assuredctrl_scanCursorData, tvb, offset, scanCursorLen, FALSE);
+            hf_assuredctrl_scanCursorData, tvb, offset, scanCursorLen, false);
         offset += scanCursorLen;
     }
 
@@ -1127,10 +1125,10 @@ static int add_assuredCtrl_txnClientFields_item (
     int offset,
     char const * const field_name)
 {
-    guint8 length = 0;
+    uint8_t length = 0;
     char data[254];     /* 254 bytes = max 253 byte string + 1 NULL byte*/
 
-    length = tvb_get_guint8(tvb, offset);
+    length = tvb_get_uint8(tvb, offset);
     offset++;
 
     tvb_memcpy(tvb, data, offset, length-1);
@@ -1146,14 +1144,14 @@ static int add_assuredCtrl_msgIdList_item (
     int offset)
 {
     int old_offset = offset;
-    guint32 msgIdCount = 0;
-    guint64 msgId = 0;
+    uint32_t msgIdCount = 0;
+    uint64_t msgId = 0;
     unsigned int i = 0;
 
     msgIdCount = tvb_get_ntohl(tvb, offset);
     offset += get_32_bit_value(tree, tvb, offset, "MsgIdCount");
 
-    proto_tree_add_item(tree, hf_assuredctrl_msgIdType, tvb, offset, 1, FALSE);
+    proto_tree_add_item(tree, hf_assuredctrl_msgIdType, tvb, offset, 1, false);
     offset++;
 
     /* Cannot call get_64_bit_value because of special formatting (i.e. MsgId[%d]) */
@@ -1173,10 +1171,10 @@ static int add_assuredCtrl_endpoint_item (
     int offset)
 {
     int old_offset = offset;
-    guint32 ackCount = 0;
+    uint32_t ackCount = 0;
     unsigned int i = 0;
 
-    proto_tree_add_item(tree, hf_assuredctrl_endpointHash, tvb, offset, 8, FALSE);
+    proto_tree_add_item(tree, hf_assuredctrl_endpointHash, tvb, offset, 8, false);
     offset += 8;
     
     ackCount = tvb_get_ntohl(tvb, offset);
@@ -1195,7 +1193,7 @@ static int add_assuredCtrl_externalAckList_item (
     int offset)
 {
     int old_offset = offset;
-    guint32 endpointCount = 0;
+    uint32_t endpointCount = 0;
     unsigned int i = 0;
 
     endpointCount = tvb_get_ntohl(tvb, offset);
@@ -1217,7 +1215,7 @@ static void add_assuredCtrl_txnResponse_item (
     proto_tree* sub_tree;
     proto_item* item;
 
-    item = proto_tree_add_item(tree, hf_assuredctrl_txnmsg_type_txnResponse, tvb, offset, size, FALSE);
+    item = proto_tree_add_item(tree, hf_assuredctrl_txnmsg_type_txnResponse, tvb, offset, size, false);
     sub_tree = proto_item_add_subtree(item, ett_TXN_msg_txnResponse_list);
     offset++;
 
@@ -1225,7 +1223,7 @@ static void add_assuredCtrl_txnResponse_item (
     offset += get_64_bit_value(sub_tree, tvb, offset, "CorrelationId");
 
     /* txnResponseSubcode is identical to xaResponseSubCode; hence using `hf_assuredctrl_xaResponseSubcode` field*/
-    proto_tree_add_item(sub_tree, hf_assuredctrl_xaResponseSubcode, tvb, offset, 4, FALSE);
+    proto_tree_add_item(sub_tree, hf_assuredctrl_xaResponseSubcode, tvb, offset, 4, false);
     offset += 4;
 }
 
@@ -1238,7 +1236,7 @@ static void add_assuredCtrl_syncPrepareRequest_item (
     proto_tree* sub_tree;
     proto_item* item;
 
-    item = proto_tree_add_item(tree, hf_assuredctrl_txnmsg_type_syncPrepareRequest, tvb, offset, size, FALSE);
+    item = proto_tree_add_item(tree, hf_assuredctrl_txnmsg_type_syncPrepareRequest, tvb, offset, size, false);
     sub_tree = proto_item_add_subtree(item, ett_TXN_msg_syncPrepareRequest_list);
     offset++;
 
@@ -1263,7 +1261,7 @@ static void add_assuredCtrl_asyncCommitRequest_item (
     proto_tree* sub_tree;
     proto_item* item;
 
-    item = proto_tree_add_item(tree, hf_assuredctrl_txnmsg_type_asyncCommitRequest, tvb, offset, size, FALSE);
+    item = proto_tree_add_item(tree, hf_assuredctrl_txnmsg_type_asyncCommitRequest, tvb, offset, size, false);
     sub_tree = proto_item_add_subtree(item, ett_TXN_msg_asyncCommitRequest_list);
     offset++;
 
@@ -1281,14 +1279,14 @@ static void add_assuredCtrl_syncCommitRequest_item (
     proto_tree* sub_tree;
     proto_item* item;
 
-    item = proto_tree_add_item(tree, hf_assuredctrl_txnmsg_type_syncCommitRequest, tvb, offset, size, FALSE);
+    item = proto_tree_add_item(tree, hf_assuredctrl_txnmsg_type_syncCommitRequest, tvb, offset, size, false);
     sub_tree = proto_item_add_subtree(item, ett_TXN_msg_syncCommitRequest_list);
     offset++;
 
     offset += get_32_bit_value(sub_tree, tvb, offset, "TxnId");
     offset += get_64_bit_value(sub_tree, tvb, offset, "CorrelationId");
 
-    proto_tree_add_item(sub_tree, hf_assuredctrl_heuristic_operation, tvb, offset, 1, FALSE);
+    proto_tree_add_item(sub_tree, hf_assuredctrl_heuristic_operation, tvb, offset, 1, false);
     offset++;
 }
 
@@ -1301,7 +1299,7 @@ static void add_assuredCtrl_syncCommitStart_item (
     proto_tree* sub_tree;
     proto_item* item;;
 
-    item = proto_tree_add_item(tree, hf_assuredctrl_txnmsg_type_syncCommitStart, tvb, offset, size, FALSE);
+    item = proto_tree_add_item(tree, hf_assuredctrl_txnmsg_type_syncCommitStart, tvb, offset, size, false);
     sub_tree = proto_item_add_subtree(item, ett_TXN_msg_syncCommitStart_list);
     offset++;
 
@@ -1326,7 +1324,7 @@ static void add_assuredCtrl_syncCommitEnd_item (
     proto_tree* sub_tree;
     proto_item* item;
 
-    item = proto_tree_add_item(tree, hf_assuredctrl_txnmsg_type_syncCommitEnd, tvb, offset, size, FALSE);
+    item = proto_tree_add_item(tree, hf_assuredctrl_txnmsg_type_syncCommitEnd, tvb, offset, size, false);
     sub_tree = proto_item_add_subtree(item, ett_TXN_msg_syncCommitEnd_list);
     offset++;
 
@@ -1343,7 +1341,7 @@ static void add_assuredCtrl_syncRespoolRequest_item (
     proto_tree* sub_tree;
     proto_item* item;
 
-    item = proto_tree_add_item(tree, hf_assuredctrl_txnmsg_type_syncRespoolRequest, tvb, offset, size, FALSE);
+    item = proto_tree_add_item(tree, hf_assuredctrl_txnmsg_type_syncRespoolRequest, tvb, offset, size, false);
     sub_tree = proto_item_add_subtree(item, ett_TXN_msg_syncRespoolRequest_list);
     offset++;
 
@@ -1361,13 +1359,13 @@ static void add_assuredCtrl_asyncRollbackRequest_item (
     proto_tree* sub_tree;
     proto_item* item;
 
-    item = proto_tree_add_item(tree, hf_assuredctrl_txnmsg_type_asyncRollbackRequest, tvb, offset, size, FALSE);
+    item = proto_tree_add_item(tree, hf_assuredctrl_txnmsg_type_asyncRollbackRequest, tvb, offset, size, false);
     sub_tree = proto_item_add_subtree(item, ett_TXN_msg_asyncRollbackRequest_list);
     offset++;
 
     offset += get_32_bit_value(sub_tree, tvb, offset, "TxnId");
 
-    proto_tree_add_item(sub_tree, hf_assuredctrl_heuristic_operation, tvb, offset, 1, FALSE);
+    proto_tree_add_item(sub_tree, hf_assuredctrl_heuristic_operation, tvb, offset, 1, false);
     offset++;
 }
 
@@ -1380,7 +1378,7 @@ static void add_assuredCtrl_syncUncommitRequest_item (
     proto_tree* sub_tree;
     proto_item* item;
 
-    item = proto_tree_add_item(tree, hf_assuredctrl_txnmsg_type_syncUncommitRequest, tvb, offset, size, FALSE);
+    item = proto_tree_add_item(tree, hf_assuredctrl_txnmsg_type_syncUncommitRequest, tvb, offset, size, false);
     sub_tree = proto_item_add_subtree(item, ett_TXN_msg_syncUncommitRequest_list);
     offset++;
 
@@ -1397,7 +1395,7 @@ static void add_assuredCtrl_payload_param_xa_item (
     int lenbytes,
     const char **str_transactionctrl_msgtype)
 {
-    guint8 msgType = tvb_get_guint8(tvb, offset);
+    uint8_t msgType = tvb_get_uint8(tvb, offset);
     *str_transactionctrl_msgtype = try_val_to_str(msgType, xamsgtypenames);
     switch (msgType) 
     {
@@ -1449,7 +1447,7 @@ static void add_assuredCtrl_payload_param_xa_item (
         default:
             proto_tree_add_item(tree,
                 hf_assuredctrl_xamsg_type_unknown,
-                tvb, offset-(lenbytes+1), size+(lenbytes+1), FALSE);
+                tvb, offset-(lenbytes+1), size+(lenbytes+1), false);
             break;
     }
 }
@@ -1462,9 +1460,9 @@ static void add_assuredCtrl_payload_param_txn_item (
     int lenbytes,
     const char **str_transactionctrl_msgtype)
 {
-    guint8 msgType = tvb_get_guint8(tvb, offset);
+    uint8_t msgType = tvb_get_uint8(tvb, offset);
     *str_transactionctrl_msgtype = try_val_to_str(msgType, txnmsgtypenames);
-    proto_tree_add_item(tree, hf_assuredctrl_txnmsg_type, tvb, offset, 1, FALSE);
+    proto_tree_add_item(tree, hf_assuredctrl_txnmsg_type, tvb, offset, 1, false);
 
     switch (msgType)
     {
@@ -1507,7 +1505,7 @@ static void add_assuredCtrl_payload_param_txn_item (
         default:
             proto_tree_add_item(tree,
                 hf_assuredctrl_txnmsg_type_unknown,
-                tvb, offset-(lenbytes+1), size+(lenbytes+1), FALSE);
+                tvb, offset-(lenbytes+1), size+(lenbytes+1), false);
             break;
     }
 }
@@ -1538,15 +1536,15 @@ static void add_FD_suback_item(
     proto_tree* sub_tree;
     proto_item* item;
     int local_offset = offset;
-    guint32 flowid = 0;
-    guint64 min = 0;
-    guint64 max = 0;
-    guint32 msgCount = 0;
-    guint64 lastMsgIdRecved = 0;
-    guint32 windowSz = 0;
+    uint32_t flowid = 0;
+    uint64_t min = 0;
+    uint64_t max = 0;
+    uint32_t msgCount = 0;
+    uint64_t lastMsgIdRecved = 0;
+    uint32_t windowSz = 0;
     
     item = proto_tree_add_item(tree, 
-        hf_assuredctrl_transactionflowdescriptorsuback_param, tvb, offset, size, FALSE);
+        hf_assuredctrl_transactionflowdescriptorsuback_param, tvb, offset, size, false);
 
     sub_tree = proto_item_add_subtree(item, ett_FD_suback_list);
     while( local_offset < offset+size )
@@ -1585,12 +1583,12 @@ static void add_FD_pubnotify_item(
     proto_tree* sub_tree;
     proto_item* item;
     int local_offset = offset;
-    guint32 flowid = 0;
-    guint32 messageCount = 0;
-    guint64 lastMsgId = 0;
+    uint32_t flowid = 0;
+    uint32_t messageCount = 0;
+    uint64_t lastMsgId = 0;
     
     item = proto_tree_add_item(tree, 
-        hf_assuredctrl_transactionflowdescriptorpubnotify_param, tvb, offset, size, FALSE);
+        hf_assuredctrl_transactionflowdescriptorpubnotify_param, tvb, offset, size, false);
 
     sub_tree = proto_item_add_subtree(item, ett_FD_pubnotify_list);
     while( local_offset < offset+size )
@@ -1626,12 +1624,12 @@ static void add_FD_puback_item(
     proto_tree* sub_tree;
     proto_item* item;
     int local_offset = offset;
-    guint32 flowid = 0;
-    guint64 lastMsgId = 0;
-    guint32 windowSz = 0;
+    uint32_t flowid = 0;
+    uint64_t lastMsgId = 0;
+    uint32_t windowSz = 0;
     
     item = proto_tree_add_item(tree, 
-        hf_assuredctrl_transactionflowdescriptorpuback_param, tvb, offset, size, FALSE);
+        hf_assuredctrl_transactionflowdescriptorpuback_param, tvb, offset, size, false);
 
     sub_tree = proto_item_add_subtree(item, ett_FD_puback_list);
     while( local_offset < offset+size )
@@ -1658,33 +1656,33 @@ static void add_EP_behaviour_item(
     proto_tree* sub_tree;
     proto_item* item;
     int     num_bool_bytes = size;
-    guint8      behaviours;
+    uint8_t      behaviours;
 
-    item = proto_tree_add_item(tree, hf_assuredctrl_epbehaviour_param, tvb, offset, size, FALSE);
+    item = proto_tree_add_item(tree, hf_assuredctrl_epbehaviour_param, tvb, offset, size, false);
 
     sub_tree = proto_item_add_subtree(item, ett_EP_behaviour_list);
     if ( num_bool_bytes >= 1 ) {
-            behaviours = tvb_get_guint8(tvb, offset);
+            behaviours = tvb_get_uint8(tvb, offset);
             /*
              * TODO: I'm sure there is a better way to handle this loonie field which contains 4 2-bit values 
              */
             if (behaviours & 0x80) {
-                proto_tree_add_item(sub_tree, hf_asssuredctrl_enableCutThrough_param, tvb, offset, 1, FALSE);
+                proto_tree_add_item(sub_tree, hf_asssuredctrl_enableCutThrough_param, tvb, offset, 1, false);
             } 
             if (behaviours & 0x40) {
-                proto_tree_add_item(sub_tree, hf_asssuredctrl_disableCutThrough_param, tvb, offset, 1, FALSE);
+                proto_tree_add_item(sub_tree, hf_asssuredctrl_disableCutThrough_param, tvb, offset, 1, false);
             }
             if (behaviours & 0x20) {
-                proto_tree_add_item(sub_tree, hf_asssuredctrl_enableNotifySender_param, tvb, offset, 1, FALSE);
+                proto_tree_add_item(sub_tree, hf_asssuredctrl_enableNotifySender_param, tvb, offset, 1, false);
             }
             if (behaviours & 0x10) {
-                proto_tree_add_item(sub_tree, hf_asssuredctrl_disableNotifySender_param, tvb, offset, 1, FALSE);
+                proto_tree_add_item(sub_tree, hf_asssuredctrl_disableNotifySender_param, tvb, offset, 1, false);
             }
             if (behaviours & 0x08) {
-                proto_tree_add_item(sub_tree, hf_asssuredctrl_enableDeliveryCount_param, tvb, offset, 1, FALSE);
+                proto_tree_add_item(sub_tree, hf_asssuredctrl_enableDeliveryCount_param, tvb, offset, 1, false);
             }
             if (behaviours & 0x04) {
-                proto_tree_add_item(sub_tree, hf_asssuredctrl_disableDeliveryCount_param, tvb, offset, 1, FALSE);
+                proto_tree_add_item(sub_tree, hf_asssuredctrl_disableDeliveryCount_param, tvb, offset, 1, false);
             }
     }
 }
@@ -1694,13 +1692,13 @@ add_assuredctrl_param(
     tvbuff_t *tvb,
     packet_info* pinfo,
     proto_tree *tree,
-    guint8 param_type,
+    uint8_t param_type,
     int offset,
     int size,
     int lenbytes,
     const char **str_transactionctrl_msgtype)
 {
-    guint8 transactionctrl_type;
+    uint8_t transactionctrl_type;
 
     // skip type byte and lenbytes
     offset += (lenbytes + 1);
@@ -1716,25 +1714,25 @@ add_assuredctrl_param(
         case ASSUREDCTRL_LAST_MSGID_SENT_PARAM:
             proto_tree_add_item(tree,
                 hf_assuredctrl_last_msgid_sent_param,
-                tvb, offset, size, FALSE);
+                tvb, offset, size, false);
             break;
 
         case ASSUREDCTRL_LAST_MSGID_ACKED_PARAM:
             proto_tree_add_item(tree,
                 hf_assuredctrl_last_msgid_acked_param,
-                tvb, offset, size, FALSE);
+                tvb, offset, size, false);
             break;
 
         case ASSUREDCTRL_WINDOW_SIZE_PARAM:
         {
-            guint32 windowSize = 0;
-            version = (tvb_get_guint8(tvb, 0) & 0x3f);            
-            if (version < 3) { msg_type = (tvb_get_guint8(tvb, 1) & 0xf0) >> 4; }
-            else { msg_type = tvb_get_guint8(tvb, 1); }
+            uint32_t windowSize = 0;
+            version = (tvb_get_uint8(tvb, 0) & 0x3f);            
+            if (version < 3) { msg_type = (tvb_get_uint8(tvb, 1) & 0xf0) >> 4; }
+            else { msg_type = tvb_get_uint8(tvb, 1); }
 
             item = proto_tree_add_item_ret_uint(tree,
                 hf_assuredctrl_window_size_param,
-                tvb, offset, size, FALSE, &windowSize);
+                tvb, offset, size, false, &windowSize);
             if (0 == windowSize) {
                 if (msg_type != 0x04) { // Not Bind request (Bind request main contain a window size param of 0)
                     expert_add_info(pinfo, item, &ei_assuredctrl_smf_expert_transport_window_zero);
@@ -1746,86 +1744,86 @@ add_assuredctrl_param(
         case ASSUREDCTRL_TRANSPORT_PRIO_PARAM:
             proto_tree_add_item(tree,
                 hf_assuredctrl_transport_prio_param,
-                tvb, offset, size, FALSE);
+                tvb, offset, size, false);
             break;
 
         case ASSUREDCTRL_APPLICATION_ACK_PARAM:
             proto_tree_add_item(tree,
                 hf_assuredctrl_application_ack_min_id_param,
-                tvb, offset, 8, FALSE);
+                tvb, offset, 8, false);
             proto_tree_add_item(tree,
                 hf_assuredctrl_application_ack_max_id_param,
-                tvb, offset+8, 8, FALSE);
+                tvb, offset+8, 8, false);
             if (size == 17) {
                 proto_tree_add_item(tree,
                     hf_assuredctrl_application_ack_outcome_param,
-                    tvb, offset+16, 1, FALSE);
+                    tvb, offset+16, 1, false);
             }
             break;
 
         case ASSUREDCTRL_FLOWID_PARAM:
             proto_tree_add_item(tree,
                 hf_assuredctrl_flowid_param,
-                tvb, offset, size, FALSE);
+                tvb, offset, size, false);
             item = proto_tree_add_item(tree, // This parameter is for easier search and filtering with flows
                 hf_smf_flowid_hidden_param,
-                tvb, offset, size, FALSE);
+                tvb, offset, size, false);
             proto_item_set_hidden(item);
             break;
 
         case ASSUREDCTRL_QUEUE_NAME_PARAM:
             proto_tree_add_item(tree,
                 hf_assuredctrl_queue_name_param,
-                tvb, offset, size, FALSE);
+                tvb, offset, size, false);
             break;
 
         case ASSUREDCTRL_DTE_NAME_PARAM:
             proto_tree_add_item(tree,
                 hf_assuredctrl_dte_name_param,
-                tvb, offset, size, FALSE);
+                tvb, offset, size, false);
             break;
 
         case ASSUREDCTRL_TOPIC_NAME_PARAM:
             proto_tree_add_item(tree,
                 hf_assuredctrl_topic_name_param,
-                tvb, offset, size, FALSE);
+                tvb, offset, size, false);
             break;
 
         case ASSUREDCTRL_FLOW_NAME_PARAM:
             proto_tree_add_item(tree,
                 hf_assuredctrl_flow_name_param,
-                tvb, offset, size, FALSE);
+                tvb, offset, size, false);
             break;
 
         case ASSUREDCTRL_DURABILITY_PARAM:
             proto_tree_add_item(tree,
                 hf_assuredctrl_durability_param,
-                tvb, offset, size, FALSE);
+                tvb, offset, size, false);
             break;
 
         case ASSUREDCTRL_ACCESS_TYPE_PARAM:
             proto_tree_add_item(tree,
                 hf_assuredctrl_access_type_param,
-                tvb, offset, size, FALSE);
+                tvb, offset, size, false);
             break;
 
         case ASSUREDCTRL_MESSAGE_SELECTOR_PARAM:
             proto_tree_add_item(tree,
                 hf_assuredctrl_message_selector_param,
-                tvb, offset, size, FALSE);
+                tvb, offset, size, false);
             break;
 
         case ASSUREDCTRL_TRANSPORT_WINDOW_SIZE_PARAM:
         {
-            guint32 windowSize = 0;
+            uint32_t windowSize = 0;
 
-            version = (tvb_get_guint8(tvb, 0) & 0x3f);            
-            if (version < 3) { msg_type = (tvb_get_guint8(tvb, 1) & 0xf0) >> 4; }
-            else { msg_type = tvb_get_guint8(tvb, 1); }
+            version = (tvb_get_uint8(tvb, 0) & 0x3f);            
+            if (version < 3) { msg_type = (tvb_get_uint8(tvb, 1) & 0xf0) >> 4; }
+            else { msg_type = tvb_get_uint8(tvb, 1); }
 
             item = proto_tree_add_item_ret_uint(tree,
                 hf_assuredctrl_transport_window_size_param,
-                tvb, offset, size, FALSE, &windowSize);
+                tvb, offset, size, false, &windowSize);
             if (0 == windowSize) {
                 if (msg_type != 0x04) { // Not Bind request (Bind request main contain a window size param of 0)
                     expert_add_info(pinfo, item, &ei_assuredctrl_smf_expert_transport_window_zero);
@@ -1837,61 +1835,61 @@ add_assuredctrl_param(
         case ASSUREDCTRL_UNBIND_LINGER_PARAM:
             proto_tree_add_item(tree,
                 hf_assuredctrl_unbind_linger_param,
-                tvb, offset, size, FALSE);
+                tvb, offset, size, false);
             break;
 
         case ASSUREDCTRL_LAST_MSGID_RECVED_PARAM:
             proto_tree_add_item(tree,
                 hf_assuredctrl_last_msgid_recved_param,
-                tvb, offset, size, FALSE);
+                tvb, offset, size, false);
             break;
 
         case ASSUREDCTRL_ALL_OTHERS_PERMISSIONS_PARAM:
             proto_tree_add_item(tree,
                 hf_assuredctrl_all_others_permissions_param,
-                tvb, offset, size, FALSE);
+                tvb, offset, size, false);
             break;
         case ASSUREDCTRL_FLOW_TYPE_PARAM:
             proto_tree_add_item(tree,
                 hf_assuredctrl_flow_type_param,
-                tvb, offset, size, FALSE);
+                tvb, offset, size, false);
             break;
         case ASSUREDCTRL_ENDPOINT_QUOTA_MB_PARAM:
             proto_tree_add_item(tree,
                 hf_assuredctrl_endpoint_quota_mb_param,
-                tvb, offset, size, FALSE);
+                tvb, offset, size, false);
             break;
         case ASSUREDCTRL_ENDPOINT_MAX_MESSAGE_SIZE_PARAM:
             proto_tree_add_item(tree,
                 hf_assuredctrl_endpoint_max_message_size_param,
-                tvb, offset, size, FALSE);
+                tvb, offset, size, false);
             break;
         case ASSUREDCTRL_GRANTED_PERMISSIONS_PARAM:
             proto_tree_add_item(tree,
                 hf_assuredctrl_granted_permissions_param,
-                tvb, offset, size, FALSE);
+                tvb, offset, size, false);
             break;
         case ASSUREDCTRL_RESPECT_TTL_PARAM:
             proto_tree_add_item(tree,
                 hf_assuredctrl_respect_ttl_param,
-                tvb, offset, size, FALSE);
+                tvb, offset, size, false);
             break;
         case ASSUREDCTRL_TRANSACTIONCTRLMESSAGETYPE_PARAM:
             proto_tree_add_item(tree,
                 hf_assuredctrl_transactionctrlmessagetype_param,
-                tvb, offset, size, FALSE);
-            transactionctrl_type = tvb_get_guint8(tvb, offset);
+                tvb, offset, size, false);
+            transactionctrl_type = tvb_get_uint8(tvb, offset);
             *str_transactionctrl_msgtype = try_val_to_str(transactionctrl_type, transactionctrlmsgtypenames);
             break;
         case ASSUREDCTRL_TRANSACTEDSESSIONID_PARAM:
             proto_tree_add_item(tree,
                 hf_assuredctrl_transactedsessionid_param,
-                tvb, offset, size, FALSE);
+                tvb, offset, size, false);
             break;
         case ASSUREDCTRL_TRANSACTEDSESSIONNAME_PARAM:
             proto_tree_add_item(tree,
                 hf_assuredctrl_transactedsessionname_param,
-                tvb, offset, size, FALSE);
+                tvb, offset, size, false);
             break;
         case ASSUREDCTRL_TRANSACTIONID_PARAM:
             add_transactionid_param(tree,
@@ -1901,13 +1899,13 @@ add_assuredctrl_param(
         case ASSUREDCTRL_TRANSACTEDSESSIONSTATE_PARAM:
             proto_tree_add_item(tree,
                 hf_assuredctrl_transactedsessionstate_param,
-                tvb, offset, size, FALSE);
+                tvb, offset, size, false);
             break;
         case ASSUREDCTRL_TRANSACTIONFLOWDESCRIPTORPUBNOTIFY_PARAM:
             /*
             proto_tree_add_item(tree,
                 hf_assuredctrl_transactionflowdescriptorpubnotify_param,
-                tvb, offset, size, FALSE);
+                tvb, offset, size, false);
                 */
                 add_FD_pubnotify_item(tree, tvb, offset, size);
             break;
@@ -1915,7 +1913,7 @@ add_assuredctrl_param(
             /*
             proto_tree_add_item(tree,
                 hf_assuredctrl_transactionflowdescriptorpuback_param,
-                tvb, offset, size, FALSE);
+                tvb, offset, size, false);
                 */
                 add_FD_puback_item(tree, tvb, offset, size);
 
@@ -1924,24 +1922,24 @@ add_assuredctrl_param(
             /*
             proto_tree_add_item(tree,
                 hf_assuredctrl_transactionflowdescriptorsuback_param,
-                tvb, offset, size, FALSE);
+                tvb, offset, size, false);
                 */
             add_FD_suback_item(tree, tvb, offset, size);
             break;
         case ASSUREDCTRL_NO_LOCAL_PARAM:
             proto_tree_add_item(tree,
                 hf_assuredctrl_no_local_param,
-                tvb, offset, size, FALSE);
+                tvb, offset, size, false);
             break;
         case ASSUREDCTRL_ACTIVEFLOWINDICATION_PARAM:
             proto_tree_add_item(tree,
                     hf_assuredctrl_activeflowindication_param,
-                    tvb, offset, size, FALSE);
+                    tvb, offset, size, false);
                 break;
         case ASSUREDCTRL_WANTFLOWCHANGEUPDATE_PARAM:
             proto_tree_add_item(tree,
                     hf_assuredctrl_wantflowchangeupdate_param,
-                    tvb, offset, size, FALSE);
+                    tvb, offset, size, false);
                 break;
         case ASSUREDCTRL_EP_BEHAVIOUR_PARAM:
             add_EP_behaviour_item(tree, tvb, offset, size);
@@ -1949,56 +1947,56 @@ add_assuredctrl_param(
         case ASSUREDCTRL_PUBLISHDERID_PARAM:
             proto_tree_add_item(tree,
                     hf_assuredctrl_publisherid_param,
-                    tvb, offset, size, FALSE);
+                    tvb, offset, size, false);
                 break;
         case ASSUREDCTRL_APPLICATION_PUBACK_PARAM:
             proto_tree_add_item(tree,
                 hf_assuredctrl_application_ack_pubid_param,
-                tvb, offset, 4, FALSE);
+                tvb, offset, 4, false);
             proto_tree_add_item(tree,
                 hf_assuredctrl_application_ack_min_id_param,
-                tvb, offset+4, 8, FALSE);
+                tvb, offset+4, 8, false);
             proto_tree_add_item(tree,
                 hf_assuredctrl_application_ack_max_id_param,
-                tvb, offset+12, 8, FALSE);
+                tvb, offset+12, 8, false);
                 break;
         case ASSUREDCTRL_NUMMSGSPOOLED_PARAM:
             proto_tree_add_item(tree,
                     hf_assuredctrl_nummsgspooled_param,
-                    tvb, offset, size, FALSE);
+                    tvb, offset, size, false);
                 break;
         case ASSUREDCTRL_CUTTHROUGH_PARAM:
             proto_tree_add_item(tree,
                     hf_assuredctrl_cutthrough_param,
-                    tvb, offset, size, FALSE);
+                    tvb, offset, size, false);
                 break;
         case ASSUREDCTRL_PUBLISHERFLAGS_PARAM:
             proto_tree_add_item(tree,
                 hf_assuredctrl_drAckConsumed_param,
-                tvb, offset, size, FALSE);
+                tvb, offset, size, false);
             break;
         case ASSUREDCTRL_APPMSGIDTYPE_PARAM:
             proto_tree_add_item(tree,
                 hf_assuredctrl_appMsgIdType_param,
-                tvb, offset, size, FALSE);
+                tvb, offset, size, false);
             break;
         case ASSUREDCTRL_QENDPOINTHASH_PARAM:
             proto_tree_add_item(tree,
                 hf_assuredctrl_qEndPointHash_param,
-                tvb, offset, size, FALSE);
+                tvb, offset, size, false);
             break;
         case ASSUREDCTRL_MAX_REDELIVERY_PARAM:
             proto_tree_add_item(tree,
                 hf_assuredctrl_max_redelivery_param,
-                tvb, offset, size, FALSE);
+                tvb, offset, size, false);
             break;
         case ASSUREDCTRL_PAYLOAD_PARAM:
             /* The ASSUREDCTRL_PAYLOAD_PARAM is only parsed on two types of assuredCtrl msgs.
                So first, parse the message again from the tvBuff and make sure it is either XACtrl or TXNCtrl msg. */
-            version = (tvb_get_guint8(tvb, 0) & 0x3f);
+            version = (tvb_get_uint8(tvb, 0) & 0x3f);
             
-            if (version < 3) { msg_type = (tvb_get_guint8(tvb, 1) & 0xf0) >> 4; }
-            else { msg_type = tvb_get_guint8(tvb, 1); }
+            if (version < 3) { msg_type = (tvb_get_uint8(tvb, 1) & 0xf0) >> 4; }
+            else { msg_type = tvb_get_uint8(tvb, 1); }
 
             /* Only parse if msg is either an XaCtrl (0x0e) or TxnCtrl (0x10). */
             if ( (msg_type != 0x0e) && (msg_type != 0x10) ) { break; }
@@ -2010,22 +2008,22 @@ add_assuredctrl_param(
         case ASSUREDCTRL_ENDPOINTID_PARAM:
             proto_tree_add_item(tree,
                     hf_assuredctrl_EndpointId_param,
-                    tvb, offset, size, FALSE);
+                    tvb, offset, size, false);
                 break;
         case ASSUREDCTRL_ACKSEQUENCENUM_PARAM:
             proto_tree_add_item(tree,
                 hf_assuredctrl_ackSequenceNum_param,
-                tvb, offset, size, FALSE);
+                tvb, offset, size, false);
             break;
         case ASSUREDCTRL_ACKRECONCILEREQ_PARAM:
             proto_tree_add_item(tree,
                 hf_assuredctrl_ackReconcileReq_param,
-                tvb, offset-(lenbytes+1), size+(lenbytes+1), FALSE);
+                tvb, offset-(lenbytes+1), size+(lenbytes+1), false);
             break;
         case ASSUREDCTRL_ACKRECONCILESTART_PARAM:
             proto_tree_add_item(tree,
                 hf_assuredctrl_ackReconcileStart_param,
-                tvb, offset-(lenbytes+1), size+(lenbytes+1), FALSE);
+                tvb, offset-(lenbytes+1), size+(lenbytes+1), false);
             break;
         case ASSUREDCTRL_TIMESTAMP_PARAM:
 	    {
@@ -2038,7 +2036,7 @@ add_assuredctrl_param(
                 proto_item* ti2;
                 proto_tree* timestamp_tree;
 
-                ti2 = proto_tree_add_item(tree, hf_assuredctrl_timestamp_param, tvb, offset, size, FALSE);
+                ti2 = proto_tree_add_item(tree, hf_assuredctrl_timestamp_param, tvb, offset, size, false);
                 timestamp_tree = proto_item_add_subtree(ti2, ett_assuredctrl_timestamp_param);
 
                     time_t epch2 = tvb_get_ntohl(tvb, offset);
@@ -2069,26 +2067,26 @@ add_assuredctrl_param(
         case ASSUREDCTRL_MAXDELIVEREDUNACKEDMSGSPERFLOW_PARAM:
             proto_tree_add_item(tree,
                 hf_assuredctrl_max_delivered_unacked_msgs_per_flow_param,
-                tvb, offset, size, FALSE);
+                tvb, offset, size, false);
             break;
         case ASSUREDCTRL_DRQUEUEPRIORITY_PARAM:
             proto_tree_add_item(tree,
                 hf_assuredctrl_dr_queue_priority_param,
-                tvb, offset, size, FALSE);
+                tvb, offset, size, false);
             break;
         case ASSUREDCTRL_STARTREPLAY_PARAM:
             {
                 proto_item* ti;
                 proto_tree* start_replay_tree;
 
-                ti = proto_tree_add_item(tree, hf_assuredctrl_start_replay_param, tvb, offset, size, FALSE);
+                ti = proto_tree_add_item(tree, hf_assuredctrl_start_replay_param, tvb, offset, size, false);
                 start_replay_tree = proto_item_add_subtree(ti, ett_assuredctrl_start_replay_param);
 
-                if (tvb_get_guint8(tvb, offset) == 0) {
+                if (tvb_get_uint8(tvb, offset) == 0) {
                     proto_tree_add_string_format(start_replay_tree, hf_assuredctrl_start_replay_type_param, tvb, offset, 1, NULL,
                         "Start Replay Location: BEGINNING");
                 }
-                else if (tvb_get_guint8(tvb, offset) == 1) {
+                else if (tvb_get_uint8(tvb, offset) == 1) {
                     time_t epch = tvb_get_ntoh64(tvb, offset + 1)/1000000000;
 
                     // The function 'strftime' is the only function that I could find that would custom-parse the 64-bit time.
@@ -2123,7 +2121,7 @@ add_assuredctrl_param(
                  * serializatoin:
                  *    rmid1:xxxxx-xxxxxxxxxxx-xxxxxxxx-xxxxxxxx  (5,11,8,8)
                  */
-                else if (tvb_get_guint8(tvb, offset) == 2) {
+                else if (tvb_get_uint8(tvb, offset) == 2) {
                     proto_tree_add_string_format(
                         start_replay_tree, hf_assuredctrl_start_replay_location_rgmid_string, tvb, offset + 1, 8, NULL,
                         "Start Replay Location: Replay Messages after: rmid1:%05x-%011lx-%08x-%08x",
@@ -2138,48 +2136,48 @@ add_assuredctrl_param(
         case ASSUREDCTRL_ENDPOINTERRORID_PARAM:
             proto_tree_add_item(tree,
                 hf_assuredctrl_endpoint_error_id_param,
-                tvb, offset, size, FALSE);
+                tvb, offset, size, false);
             break;
         case ASSUREDCTRL_RETRANSMIT_REQUEST_PARAM:
             proto_tree_add_item(tree,
                 hf_assuredctrl_retransmit_request_param,
-                tvb, offset, size, FALSE);  // param only consists of length/uh/type so I'm having it highlight it all
+                tvb, offset, size, false);  // param only consists of length/uh/type so I'm having it highlight it all
             break;
         case ASSUREDCTRL_SPOOLER_UNIQUE_ID_PARAM:
             proto_tree_add_item(tree,
                 hf_assuredctrl_spooler_unique_id_param,
-                tvb, offset, size, FALSE);
+                tvb, offset, size, false);
             break;
         case ASSUREDCTRL_TRANSACTION_GET_SESSION_STATE_AND_ID:
         	proto_tree_add_item(tree,
                 hf_assuredctrl_transaction_get_session_state_and_id,
-                tvb, offset, size, FALSE);
+                tvb, offset, size, false);
             break;
         case ASSUREDCTRL_PARTITION_GROUP_ID:
             proto_tree_add_item(tree,
                 hf_assuredctrl_partition_group_id,
-                tvb, offset, size, FALSE);
+                tvb, offset, size, false);
             break;
         case ASSUREDCTRL_REDELIVERY_DELAY_CONFIGURATION:
             proto_tree_add_item(tree,
                 hf_assuredctrl_redelivery_delay_config_initial_interval_ms,
-                tvb, offset, 4, FALSE);
+                tvb, offset, 4, false);
             proto_tree_add_item(tree,
                 hf_assuredctrl_redelivery_delay_config_max_interval_ms,
-                tvb, offset+4, 4, FALSE);
+                tvb, offset+4, 4, false);
             proto_tree_add_item(tree,
                 hf_assuredctrl_redelivery_delay_config_back_off_multiplier,
-                tvb, offset+8, 2, FALSE);
+                tvb, offset+8, 2, false);
             if (size > 10) {
                 proto_tree_add_item(tree,
                     hf_assuredctrl_redelivery_delay_config_rfu,
-                    tvb, offset+10, size-10, FALSE);
+                    tvb, offset+10, size-10, false);
             }
             break;
         default:
             proto_tree_add_item(tree,
                 hf_assuredctrl_unknown_param,
-                tvb, offset-(lenbytes+1), size+(lenbytes+1), FALSE);
+                tvb, offset-(lenbytes+1), size+(lenbytes+1), false);
         break;
     }
     smf_analysis_assuredctrl_param(tvb, pinfo, param_type, offset, size);
@@ -2195,17 +2193,17 @@ dissect_assuredctrl_param(
 {
     int param_len;
     int len_bytes; //number of bytes used for length
-    guint8 param_type;
+    uint8_t param_type;
 
     /* Is it a pad byte? */
-    if (tvb_get_guint8(tvb, offset) == 0)
+    if (tvb_get_uint8(tvb, offset) == 0)
     {
-        proto_tree_add_item(tree, hf_assuredctrl_pad_byte, tvb, offset, 1, FALSE);
+        proto_tree_add_item(tree, hf_assuredctrl_pad_byte, tvb, offset, 1, false);
         return 1;
     }
     
-    param_type = tvb_get_guint8(tvb, offset) & 0x3f;
-    param_len  = tvb_get_guint8(tvb, offset+1);
+    param_type = tvb_get_uint8(tvb, offset) & 0x3f;
+    param_len  = tvb_get_uint8(tvb, offset+1);
     if (param_len == 0) {
         param_len = tvb_get_ntohl(tvb, offset+2); //32bit len starts after the 0
         len_bytes = 5;
@@ -2352,33 +2350,33 @@ dissect_assuredctrl(tvbuff_t *tvb, packet_info *pinfo, proto_tree *tree, void* d
    offset to the end of the packet. */
 
 /* create display subtree for the protocol */
-        ti = proto_tree_add_item(tree, proto_assuredctrl, tvb, 0, -1, FALSE);
+        ti = proto_tree_add_item(tree, proto_assuredctrl, tvb, 0, -1, false);
 
         assuredctrl_tree = proto_item_add_subtree(ti, ett_assuredctrl);
 
-        if ((tvb_get_guint8(tvb, 0) & 0x3f) < 3) {
+        if ((tvb_get_uint8(tvb, 0) & 0x3f) < 3) {
             /* Dissect header fields */
-            proto_tree_add_item(assuredctrl_tree, hf_assuredctrl_header_rfu,    tvb, 0, 1, FALSE);
-            proto_tree_add_item(assuredctrl_tree, hf_assuredctrl_version,       tvb, 0, 1, FALSE);
-            proto_tree_add_item(assuredctrl_tree, hf_assuredctrl_msg_type,      tvb, 1, 1, FALSE);
-            proto_tree_add_item(assuredctrl_tree, hf_assuredctrl_msg_len,       tvb, 1, 2, FALSE);
+            proto_tree_add_item(assuredctrl_tree, hf_assuredctrl_header_rfu,    tvb, 0, 1, false);
+            proto_tree_add_item(assuredctrl_tree, hf_assuredctrl_version,       tvb, 0, 1, false);
+            proto_tree_add_item(assuredctrl_tree, hf_assuredctrl_msg_type,      tvb, 1, 1, false);
+            proto_tree_add_item(assuredctrl_tree, hf_assuredctrl_msg_len,       tvb, 1, 2, false);
 
             /* Dissect parameters */
             header_len = tvb_get_ntohs(tvb, 1) & 0xfff;
             dissect_assuredctrl_params(tvb, pinfo, 3, 4*header_len, assuredctrl_tree, &str_transactionctrl_msgtype);
-            msgtype = (tvb_get_guint8(tvb, 1) & 0xf0) >> 4;
+            msgtype = (tvb_get_uint8(tvb, 1) & 0xf0) >> 4;
         }
         else {
             /* Dissect header fields */
-            proto_tree_add_item(assuredctrl_tree, hf_assuredctrl_header_rfu,    tvb, 0, 1, FALSE);
-            proto_tree_add_item(assuredctrl_tree, hf_assuredctrl_version,       tvb, 0, 1, FALSE);
-            proto_tree_add_item(assuredctrl_tree, hf_assuredctrl_msg_type_v3,   tvb, 1, 1, FALSE);
-            proto_tree_add_item(assuredctrl_tree, hf_assuredctrl_msg_len_v3,    tvb, 2, 4, FALSE);
+            proto_tree_add_item(assuredctrl_tree, hf_assuredctrl_header_rfu,    tvb, 0, 1, false);
+            proto_tree_add_item(assuredctrl_tree, hf_assuredctrl_version,       tvb, 0, 1, false);
+            proto_tree_add_item(assuredctrl_tree, hf_assuredctrl_msg_type_v3,   tvb, 1, 1, false);
+            proto_tree_add_item(assuredctrl_tree, hf_assuredctrl_msg_len_v3,    tvb, 2, 4, false);
 
             /* Dissect parameters */
             header_len = tvb_get_ntohl(tvb, 2);
             dissect_assuredctrl_params(tvb, pinfo, 6, header_len, assuredctrl_tree, &str_transactionctrl_msgtype);
-            msgtype = tvb_get_guint8(tvb, 1) & 0xff;
+            msgtype = tvb_get_uint8(tvb, 1) & 0xff;
         }
 
         smf_analysis_assuredctrl(tvb, pinfo, assuredctrl_tree);
@@ -3117,7 +3115,7 @@ proto_register_assuredctrl(void)
     };
 
 /* Setup protocol subtree array */
-    static gint *ett[] = {
+    static int *ett[] = {
         &ett_assuredctrl,
         &ett_FD_suback_list,
         &ett_FD_puback_list,
@@ -3193,7 +3191,7 @@ proto_register_assuredctrl(void)
 void
 proto_reg_handoff_assuredctrl(void)
 {
-    static gboolean inited = FALSE;
+    static bool inited = false;
     
     if (!inited) {
 
@@ -3202,7 +3200,7 @@ proto_reg_handoff_assuredctrl(void)
         (void)create_dissector_handle(dissect_assuredctrl, proto_assuredctrl);
 	//dissector_add("smf.encap_proto", 0x8, assuredctrl_handle);
         
-        inited = TRUE;
+        inited = true;
     }
         
         /* 

--- a/src/smf/packet-clientctrl.c
+++ b/src/smf/packet-clientctrl.c
@@ -29,8 +29,6 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include <glib.h>
-
 #include <epan/packet.h>
 #include <epan/prefs.h>
 #include <epan/wmem_scopes.h>
@@ -137,13 +135,13 @@ static int hf_clientctrl_client_capabilities_param_bool_pq = -1;
 static int hf_clientctrl_client_capabilities_param_bool_rd_lt = -1;
 
 /* Global sample preference ("controls" display of numbers) */
-//static gboolean gPREF_HEX = FALSE;
+//static bool gPREF_HEX = false;
 
 /* Initialize the subtree pointers */
-static gint ett_clientctrl = -1;
-static gint ett_clientctrl_rtr_capabilities_param = -1;
-static gint ett_clientctrl_rtr_capabilities_extended_param = -1;
-static gint ett_clientctrl_client_capabilities_param = -1;
+static int ett_clientctrl = -1;
+static int ett_clientctrl_rtr_capabilities_param = -1;
+static int ett_clientctrl_rtr_capabilities_extended_param = -1;
+static int ett_clientctrl_client_capabilities_param = -1;
 
 // ClientCtrl Parameters
 #define CLIENTCTRL_SOFTWAREVERSION_PARAM	        0x00
@@ -215,7 +213,7 @@ void clientctrl_dissect_client_capabilities_param(
     proto_tree* tree,
     int offset,
     int size,
-    gboolean nonBoolean _U_)
+    bool nonBoolean _U_)
 {
 //This was written in May 2019. In May 2019, there are no non-boolean client capabilities so this section of
 //the program will never be used.
@@ -223,43 +221,43 @@ void clientctrl_dissect_client_capabilities_param(
 //written in this function but commented out.
     proto_item*   ti;
     proto_tree*   cap_tree;
-    // guint8        num_bool_cap;
+    // uint8_t        num_bool_cap;
     // Non-boolean Client Capabilities
-    // guint8        cap_type;
+    // uint8_t        cap_type;
     // int           num_bool_bytes;
     // int           cap_offset, cap_len, cap_offset_end;
     // int           rtrcaps[LAST_CLIENT_CAP_PARAM + 1];
 
-    // num_bool_cap = tvb_get_guint8(tvb, offset);
+    // num_bool_cap = tvb_get_uint8(tvb, offset);
     // Non-boolean Client Capabilities
     // num_bool_bytes = (num_bool_cap + 7) / 8;
 
     //if (nonBoolean) {
         //Non-boolean Client Capabilities
-        //ti = proto_tree_add_item(tree, hf_clientctrl_client_capabilities_extended_param, tvb, offset, size, FALSE);
+        //ti = proto_tree_add_item(tree, hf_clientctrl_client_capabilities_extended_param, tvb, offset, size, false);
     //}
     //else {
-        ti = proto_tree_add_item(tree, hf_clientctrl_client_capabilities_param, tvb, offset, size, FALSE);
+        ti = proto_tree_add_item(tree, hf_clientctrl_client_capabilities_param, tvb, offset, size, false);
     //}
 
     cap_tree = proto_item_add_subtree(ti, ett_clientctrl_client_capabilities_param);
 
-    proto_tree_add_item(cap_tree, hf_clientctrl_client_capabilities_param_num_bool, tvb, offset, 1, FALSE);
-    proto_tree_add_item(cap_tree, hf_clientctrl_client_capabilities_param_bool_unbind_ack, tvb, offset + 1, 1, FALSE);
-    proto_tree_add_item(cap_tree, hf_clientctrl_client_capabilities_param_bool_bind_ack_errorId, tvb, offset + 1, 1, FALSE);
-    proto_tree_add_item(cap_tree, hf_clientctrl_client_capabilities_param_bool_pq, tvb, offset + 1, 1, FALSE);
-    proto_tree_add_item(cap_tree, hf_clientctrl_client_capabilities_param_bool_rd_lt, tvb, offset + 1, 1, FALSE);
+    proto_tree_add_item(cap_tree, hf_clientctrl_client_capabilities_param_num_bool, tvb, offset, 1, false);
+    proto_tree_add_item(cap_tree, hf_clientctrl_client_capabilities_param_bool_unbind_ack, tvb, offset + 1, 1, false);
+    proto_tree_add_item(cap_tree, hf_clientctrl_client_capabilities_param_bool_bind_ack_errorId, tvb, offset + 1, 1, false);
+    proto_tree_add_item(cap_tree, hf_clientctrl_client_capabilities_param_bool_pq, tvb, offset + 1, 1, false);
+    proto_tree_add_item(cap_tree, hf_clientctrl_client_capabilities_param_bool_rd_lt, tvb, offset + 1, 1, false);
 }
 
 static void 
 add_clientctrl_rtr_cap_extended_param(
     proto_tree    *tree,
-    guint8        cap_type,
+    uint8_t        cap_type,
     tvbuff_t*     tvb,
     int           offset)
 {
-    guint8 versionFrom = 0;
-    guint8 versionTo = 0;
+    uint8_t versionFrom = 0;
+    uint8_t versionTo = 0;
     
     int rtrcapExtended[LAST_RTR_CAP_EXT_PARAM + 1];
     rtrcapExtended[CLIENTCTRL_RTR_CAPABILITIES_PARAM_SUPPORTED_ADCTRL_VERSIONS] = hf_clientctrl_rtr_capabilities_param_supported_adctrl_version_string;
@@ -269,8 +267,8 @@ add_clientctrl_rtr_cap_extended_param(
     strings[CLIENTCTRL_RTR_CAPABILITIES_PARAM_SUPPORTED_ADCTRL_VERSIONS] = "AdCtrl";
     strings[CLIENTCTRL_RTR_CAPABILITIES_PARAM_SUPPORTED_XACTRL_VERSIONS] = "XaCtrl";
 
-    versionFrom = tvb_get_guint8(tvb, offset);
-    versionTo = tvb_get_guint8(tvb, offset + 1);
+    versionFrom = tvb_get_uint8(tvb, offset);
+    versionTo = tvb_get_uint8(tvb, offset + 1);
 
     proto_tree_add_string_format(
         tree, rtrcapExtended[cap_type], tvb, offset, 2, NULL,
@@ -284,19 +282,19 @@ clientctrl_dissect_rtr_capabilities_param(
     proto_tree *tree,
     int offset,
     int size,
-    gboolean extended)
+    bool extended)
 {
     proto_item   *ti;
     proto_tree   *cap_tree;
-    guint8 num_bool_cap;
-    guint non_bool_cap_type;
+    uint8_t num_bool_cap;
+    unsigned int non_bool_cap_type;
     int non_bool_cap_length;
     int non_bool_caps_end;
     int non_bool_cap_offset;
     int	num_bool_bytes = 0;
     int rtrcaps[LAST_RTR_CAP_PARAM + 1];
 
-	num_bool_cap = tvb_get_guint8(tvb, offset);
+	num_bool_cap = tvb_get_uint8(tvb, offset);
         if (num_bool_cap > 0) {
             num_bool_bytes = (num_bool_cap - 1) / 8 + 1;
         }
@@ -308,59 +306,59 @@ clientctrl_dissect_rtr_capabilities_param(
         
     
     if (extended) {
-        ti = proto_tree_add_item(tree, hf_clientctrl_rtr_capabilities_extended_param, tvb, offset, size, FALSE);
+        ti = proto_tree_add_item(tree, hf_clientctrl_rtr_capabilities_extended_param, tvb, offset, size, false);
         cap_tree = proto_item_add_subtree(ti, ett_clientctrl_rtr_capabilities_extended_param);
     } 
     else {
-        ti = proto_tree_add_item(tree, hf_clientctrl_rtr_capabilities_param, tvb, offset, size, FALSE);
+        ti = proto_tree_add_item(tree, hf_clientctrl_rtr_capabilities_param, tvb, offset, size, false);
 
         cap_tree = proto_item_add_subtree(ti, ett_clientctrl_rtr_capabilities_param);
     }
 
-    proto_tree_add_item(cap_tree, hf_clientctrl_rtr_capabilities_param_num_bool, tvb, offset, 1, FALSE);
+    proto_tree_add_item(cap_tree, hf_clientctrl_rtr_capabilities_param_num_bool, tvb, offset, 1, false);
 
         if (num_bool_bytes >= 1) {
-            proto_tree_add_item(cap_tree, hf_clientctrl_rtr_capabilities_param_bool_jndi, tvb, offset + 1, 1, FALSE);
-            proto_tree_add_item(cap_tree, hf_clientctrl_rtr_capabilities_param_bool_compression, tvb, offset + 1, 1, FALSE);
-            proto_tree_add_item(cap_tree, hf_clientctrl_rtr_capabilities_param_bool_sub_flow_gtd, tvb, offset + 1, 1, FALSE);
-            proto_tree_add_item(cap_tree, hf_clientctrl_rtr_capabilities_param_bool_temp_endpt, tvb, offset + 1, 1, FALSE);
-            proto_tree_add_item(cap_tree, hf_clientctrl_rtr_capabilities_param_bool_pub_flow_gtd, tvb, offset + 1, 1, FALSE);
-            proto_tree_add_item(cap_tree, hf_clientctrl_rtr_capabilities_param_bool_browser, tvb, offset + 1, 1, FALSE);
-            proto_tree_add_item(cap_tree, hf_clientctrl_rtr_capabilities_param_bool_endpoint_management, tvb, offset + 1, 1, FALSE);
-            proto_tree_add_item(cap_tree, hf_clientctrl_rtr_capabilities_param_bool_selector, tvb, offset + 1, 1, FALSE);
+            proto_tree_add_item(cap_tree, hf_clientctrl_rtr_capabilities_param_bool_jndi, tvb, offset + 1, 1, false);
+            proto_tree_add_item(cap_tree, hf_clientctrl_rtr_capabilities_param_bool_compression, tvb, offset + 1, 1, false);
+            proto_tree_add_item(cap_tree, hf_clientctrl_rtr_capabilities_param_bool_sub_flow_gtd, tvb, offset + 1, 1, false);
+            proto_tree_add_item(cap_tree, hf_clientctrl_rtr_capabilities_param_bool_temp_endpt, tvb, offset + 1, 1, false);
+            proto_tree_add_item(cap_tree, hf_clientctrl_rtr_capabilities_param_bool_pub_flow_gtd, tvb, offset + 1, 1, false);
+            proto_tree_add_item(cap_tree, hf_clientctrl_rtr_capabilities_param_bool_browser, tvb, offset + 1, 1, false);
+            proto_tree_add_item(cap_tree, hf_clientctrl_rtr_capabilities_param_bool_endpoint_management, tvb, offset + 1, 1, false);
+            proto_tree_add_item(cap_tree, hf_clientctrl_rtr_capabilities_param_bool_selector, tvb, offset + 1, 1, false);
         }
         if (num_bool_bytes >= 2) {
-            proto_tree_add_item(cap_tree, hf_clientctrl_rtr_capabilities_param_bool_endpoint_message_ttl, tvb, offset + 2, 1, FALSE);
-            proto_tree_add_item(cap_tree, hf_clientctrl_rtr_capabilities_param_bool_queue_subscriptions, tvb, offset + 2, 1, FALSE);
-            proto_tree_add_item(cap_tree, hf_clientctrl_rtr_capabilities_param_bool_flow_recover, tvb, offset + 2, 1, FALSE);
-            proto_tree_add_item(cap_tree, hf_clientctrl_rtr_capabilities_param_bool_subscription_manager, tvb, offset + 2, 1, FALSE);
-            proto_tree_add_item(cap_tree, hf_clientctrl_rtr_capabilities_param_bool_message_eliding, tvb, offset + 2, 1, FALSE);
-            proto_tree_add_item(cap_tree, hf_clientctrl_rtr_capabilities_param_bool_transacted_sessions, tvb, offset + 2, 1, FALSE);
-            proto_tree_add_item(cap_tree, hf_clientctrl_rtr_capabilities_param_bool_no_local, tvb, offset + 2, 1, FALSE);
-            proto_tree_add_item(cap_tree, hf_clientctrl_rtr_capabilities_param_bool_flow_change_updates, tvb, offset + 2, 1, FALSE);
+            proto_tree_add_item(cap_tree, hf_clientctrl_rtr_capabilities_param_bool_endpoint_message_ttl, tvb, offset + 2, 1, false);
+            proto_tree_add_item(cap_tree, hf_clientctrl_rtr_capabilities_param_bool_queue_subscriptions, tvb, offset + 2, 1, false);
+            proto_tree_add_item(cap_tree, hf_clientctrl_rtr_capabilities_param_bool_flow_recover, tvb, offset + 2, 1, false);
+            proto_tree_add_item(cap_tree, hf_clientctrl_rtr_capabilities_param_bool_subscription_manager, tvb, offset + 2, 1, false);
+            proto_tree_add_item(cap_tree, hf_clientctrl_rtr_capabilities_param_bool_message_eliding, tvb, offset + 2, 1, false);
+            proto_tree_add_item(cap_tree, hf_clientctrl_rtr_capabilities_param_bool_transacted_sessions, tvb, offset + 2, 1, false);
+            proto_tree_add_item(cap_tree, hf_clientctrl_rtr_capabilities_param_bool_no_local, tvb, offset + 2, 1, false);
+            proto_tree_add_item(cap_tree, hf_clientctrl_rtr_capabilities_param_bool_flow_change_updates, tvb, offset + 2, 1, false);
         }
         if (num_bool_bytes >= 3) {
-            proto_tree_add_item(cap_tree, hf_clientctrl_rtr_capabilities_param_bool_sequenced_topics, tvb, offset + 3, 1, FALSE);
-            proto_tree_add_item(cap_tree, hf_clientctrl_rtr_capabilities_param_bool_discard_behaviour, tvb, offset + 3, 1, FALSE);
-            proto_tree_add_item(cap_tree, hf_clientctrl_rtr_capabilities_param_bool_cut_through, tvb, offset + 3, 1, FALSE);
-            proto_tree_add_item(cap_tree, hf_clientctrl_rtr_capabilities_param_bool_openmama, tvb, offset + 3, 1, FALSE);
-            proto_tree_add_item(cap_tree, hf_clientctrl_rtr_capabilities_param_bool_replay, tvb, offset + 3, 1, FALSE);
-            proto_tree_add_item(cap_tree, hf_clientctrl_rtr_capabilities_param_bool_compressed_ssl, tvb, offset + 3, 1, FALSE);
-            proto_tree_add_item(cap_tree, hf_clientctrl_rtr_capabilities_param_bool_long_selectors, tvb, offset + 3, 1, FALSE);
-            proto_tree_add_item(cap_tree, hf_clientctrl_rtr_capabilities_param_bool_shared_subs, tvb, offset + 3, 1, FALSE);
+            proto_tree_add_item(cap_tree, hf_clientctrl_rtr_capabilities_param_bool_sequenced_topics, tvb, offset + 3, 1, false);
+            proto_tree_add_item(cap_tree, hf_clientctrl_rtr_capabilities_param_bool_discard_behaviour, tvb, offset + 3, 1, false);
+            proto_tree_add_item(cap_tree, hf_clientctrl_rtr_capabilities_param_bool_cut_through, tvb, offset + 3, 1, false);
+            proto_tree_add_item(cap_tree, hf_clientctrl_rtr_capabilities_param_bool_openmama, tvb, offset + 3, 1, false);
+            proto_tree_add_item(cap_tree, hf_clientctrl_rtr_capabilities_param_bool_replay, tvb, offset + 3, 1, false);
+            proto_tree_add_item(cap_tree, hf_clientctrl_rtr_capabilities_param_bool_compressed_ssl, tvb, offset + 3, 1, false);
+            proto_tree_add_item(cap_tree, hf_clientctrl_rtr_capabilities_param_bool_long_selectors, tvb, offset + 3, 1, false);
+            proto_tree_add_item(cap_tree, hf_clientctrl_rtr_capabilities_param_bool_shared_subs, tvb, offset + 3, 1, false);
         }
         if (num_bool_bytes >= 4) {
-            proto_tree_add_item(cap_tree, hf_clientctrl_rtr_capabilities_param_bool_br_replay_errorid, tvb, offset + 4, 1, FALSE);
-            proto_tree_add_item(cap_tree, hf_clientctrl_rtr_capabilities_param_bool_ad_appack_failed, tvb, offset + 4, 1, FALSE);
-            proto_tree_add_item(cap_tree, hf_clientctrl_rtr_capabilities_param_bool_var_len_ext_param, tvb, offset + 4, 1, FALSE);
-            proto_tree_add_item(cap_tree, hf_clientctrl_rtr_capabilities_param_bool_rfu, tvb, offset + 4, 1, FALSE);
+            proto_tree_add_item(cap_tree, hf_clientctrl_rtr_capabilities_param_bool_br_replay_errorid, tvb, offset + 4, 1, false);
+            proto_tree_add_item(cap_tree, hf_clientctrl_rtr_capabilities_param_bool_ad_appack_failed, tvb, offset + 4, 1, false);
+            proto_tree_add_item(cap_tree, hf_clientctrl_rtr_capabilities_param_bool_var_len_ext_param, tvb, offset + 4, 1, false);
+            proto_tree_add_item(cap_tree, hf_clientctrl_rtr_capabilities_param_bool_rfu, tvb, offset + 4, 1, false);
         }
 
     if (extended) {
         non_bool_caps_end = offset - 5 + size;
         non_bool_cap_offset = offset + 1 + num_bool_bytes;
         for (; non_bool_cap_offset < non_bool_caps_end;) {
-            non_bool_cap_type = tvb_get_guint8(tvb, non_bool_cap_offset);
+            non_bool_cap_type = tvb_get_uint8(tvb, non_bool_cap_offset);
             non_bool_cap_length = tvb_get_ntohl(tvb, non_bool_cap_offset + 1);
             add_clientctrl_rtr_cap_extended_param(cap_tree, non_bool_cap_type, tvb, non_bool_cap_offset + 5);
             non_bool_cap_offset += non_bool_cap_length;
@@ -370,9 +368,9 @@ clientctrl_dissect_rtr_capabilities_param(
         non_bool_caps_end = offset - 5 + size;
         non_bool_cap_offset = offset + 1 + num_bool_bytes;
         for (; non_bool_cap_offset < non_bool_caps_end;) {
-            non_bool_cap_type = tvb_get_guint8(tvb, non_bool_cap_offset);
+            non_bool_cap_type = tvb_get_uint8(tvb, non_bool_cap_offset);
             non_bool_cap_length = tvb_get_ntohl(tvb, non_bool_cap_offset + 1);
-            proto_tree_add_item(cap_tree, rtrcaps[non_bool_cap_type], tvb, non_bool_cap_offset + 5, non_bool_cap_length - 5, FALSE);
+            proto_tree_add_item(cap_tree, rtrcaps[non_bool_cap_type], tvb, non_bool_cap_offset + 5, non_bool_cap_length - 5, false);
             non_bool_cap_offset += non_bool_cap_length;
         }
     }
@@ -383,13 +381,13 @@ static void
 add_clientctrl_param(
     tvbuff_t *tvb,
     proto_tree *tree,
-    guint8 param_type,
+    uint8_t param_type,
     int offset,
-    guint32 size)
+    uint32_t size)
 {
 	int ccparams[LAST_CLIENTCTRL_PARAM+1];
-	guint8 dto_local_pri;
-	guint8 dto_network_pri;
+	uint8_t dto_local_pri;
+	uint8_t dto_network_pri;
 	char* buffer;
     
 	size -= 5;
@@ -444,34 +442,34 @@ add_clientctrl_param(
         case CLIENTCTRL_MQTT_CLEAN_SESSION_TYPE_PARAM:
 		proto_tree_add_item(tree,
 		                    ccparams[param_type],
-				    tvb, offset, size, FALSE);
+				    tvb, offset, size, false);
 		break;
 
     	case CLIENTCTRL_RTR_CAPABILITIES_PARAM:
-        	clientctrl_dissect_rtr_capabilities_param(tvb, tree, offset, size, FALSE);
+        	clientctrl_dissect_rtr_capabilities_param(tvb, tree, offset, size, false);
         	break;
         case CLIENTCTRL_RTR_CAPABILITIES_EXTENDED_PARAM:
-        	clientctrl_dissect_rtr_capabilities_param(tvb, tree, offset, size, TRUE);
+        	clientctrl_dissect_rtr_capabilities_param(tvb, tree, offset, size, true);
         	break;
 
 	case CLIENTCTRL_DELIVERTOONEPRIORITY_PARAM:
-		dto_local_pri = tvb_get_guint8(tvb, offset);
-		dto_network_pri = tvb_get_guint8(tvb, offset+1);
+		dto_local_pri = tvb_get_uint8(tvb, offset);
+		dto_network_pri = tvb_get_uint8(tvb, offset+1);
                 buffer = (char*)wmem_alloc(wmem_packet_scope(), 100);
 		g_snprintf(buffer, 100, "Local=%d Network=%d", dto_local_pri, dto_network_pri);
 		proto_tree_add_string(tree, ccparams[CLIENTCTRL_DELIVERTOONEPRIORITY_PARAM],
                                       tvb, offset, size, buffer);
 		break;
         case CLIENTCTRL_CLIENT_CAPABILITIES_PARAM:
-                clientctrl_dissect_client_capabilities_param(tvb, tree, offset, size, FALSE);
+                clientctrl_dissect_client_capabilities_param(tvb, tree, offset, size, false);
                 break;
     case CLIENTCTRL_KEEP_ALIVE_INTERVAL_PARAM:
-        proto_tree_add_item(tree, ccparams[param_type], tvb, offset, size, FALSE);
+        proto_tree_add_item(tree, ccparams[param_type], tvb, offset, size, false);
         break;
     default:
                 proto_tree_add_item(tree,
                 hf_clientctrl_unknown_param,
-                tvb, offset-5, size+5, FALSE);
+                tvb, offset-5, size+5, false);
                 break;
     }
 }
@@ -482,10 +480,10 @@ dissect_clientctrl_param(
     int offset, 
     proto_tree *tree)
 {
-    guint32 param_len;
-    guint8 param_type;
+    uint32_t param_len;
+    uint8_t param_type;
 
-    param_type = tvb_get_guint8(tvb, offset) & 0x7f;
+    param_type = tvb_get_uint8(tvb, offset) & 0x7f;
 
 	offset++;
     param_len  = tvb_get_ntohl(tvb, offset);
@@ -627,22 +625,22 @@ dissect_clientctrl(tvbuff_t *tvb, packet_info *pinfo _U_, proto_tree *tree, void
    offset to the end of the packet. */
 
 /* create display subtree for the protocol */
-		ti = proto_tree_add_item(tree, proto_clientctrl, tvb, 0, -1, FALSE);
+		ti = proto_tree_add_item(tree, proto_clientctrl, tvb, 0, -1, false);
 
 		clientctrl_tree = proto_item_add_subtree(ti, ett_clientctrl);
 
         /* Dissect header fields */
 		proto_tree_add_item(clientctrl_tree,
-			hf_clientctrl_uh, tvb, 0, 1, FALSE);
+			hf_clientctrl_uh, tvb, 0, 1, false);
 		proto_tree_add_item(clientctrl_tree,
-			hf_clientctrl_rfu, tvb, 0, 1, FALSE);
+			hf_clientctrl_rfu, tvb, 0, 1, false);
 		proto_tree_add_item(clientctrl_tree,
-			hf_clientctrl_version, tvb, 0, 1, FALSE);
+			hf_clientctrl_version, tvb, 0, 1, false);
 
 		proto_tree_add_item(clientctrl_tree,
-			hf_clientctrl_msg_type, tvb, 1, 1, FALSE);
+			hf_clientctrl_msg_type, tvb, 1, 1, false);
 		proto_tree_add_item(clientctrl_tree,
-			hf_clientctrl_msg_len, tvb, 2, 4, FALSE);
+			hf_clientctrl_msg_len, tvb, 2, 4, false);
 
         /* Dissect parameters */
 		header_len = tvb_get_ntohl(tvb, 2);
@@ -650,7 +648,7 @@ dissect_clientctrl(tvbuff_t *tvb, packet_info *pinfo _U_, proto_tree *tree, void
         dissect_clientctrl_params(tvb, 6, header_len, clientctrl_tree);
 
 		/* Figure out type of message and put it on the shared parent info */
-		msgtype = tvb_get_guint8(tvb, 1) ;
+		msgtype = tvb_get_uint8(tvb, 1) ;
 		str_msgtype = try_val_to_str(msgtype, msgtypenames);
 
 		if (str_msgtype) {
@@ -1066,7 +1064,7 @@ proto_register_clientctrl(void)
 	};
 
 /* Setup protocol subtree array */
-	static gint *ett[] = {
+	static int *ett[] = {
 		&ett_clientctrl,
 		&ett_clientctrl_rtr_capabilities_param,
                 &ett_clientctrl_rtr_capabilities_extended_param,
@@ -1108,14 +1106,14 @@ proto_register_clientctrl(void)
 void
 proto_reg_handoff_clientctrl(void)
 {
-	static gboolean inited = FALSE;
+	static bool inited = false;
         
 	if (!inited) {
 
 	    //dissector_handle_t clientctrl_handle;
 	    //clientctrl_handle = create_dissector_handle(dissect_clientctrl, proto_clientctrl);
             (void)create_dissector_handle(dissect_clientctrl, proto_clientctrl);
-	    inited = TRUE;
+	    inited = true;
 	}
         
         /* 

--- a/src/smf/packet-matelink.c
+++ b/src/smf/packet-matelink.c
@@ -54,7 +54,7 @@ static int global_matelink_port = 8741;
 
 static dissector_handle_t matelink_handle;
 
-static gboolean matelink_desegment = TRUE;
+static bool matelink_desegment = true;
 
 /* Header */
 static int hf_matelink_type = -1;
@@ -105,7 +105,7 @@ static int  hf_matelink_transheader_checksum= -1;
 static int  hf_matelink_transheader_sequence= -1;
 
 /* Initialize the subtree pointers */
-static gint ett_matelink = -1;
+static int ett_matelink = -1;
 
 enum MateLinkMessage
 {
@@ -179,7 +179,7 @@ static const value_string adbChkSumType_name[] =
 { CHKSUM_MD5, "MD5"},
 };
 
-static const guint32 MAX_MSG_SIZE_30MB = 32 * 1024 * 1024;
+static const uint32_t MAX_MSG_SIZE_30MB = 32 * 1024 * 1024;
 
 /* if we return 0, it means the current PDU is deferred until we
 * get the next packet.
@@ -188,7 +188,7 @@ static const guint32 MAX_MSG_SIZE_30MB = 32 * 1024 * 1024;
 * and we move on to the next packet.
 * If everything is OK return the length of the smf message
 */
-static guint32 test_matelink(tvbuff_t *tvb, packet_info* pinfo, int offset)
+static uint32_t test_matelink(tvbuff_t *tvb, packet_info* pinfo, int offset)
 {
     // If the remaining length is less then 12, we do not have enough to test
     int remainingLength = tvb_captured_length(tvb) - offset;
@@ -198,13 +198,13 @@ static guint32 test_matelink(tvbuff_t *tvb, packet_info* pinfo, int offset)
         return 1;
     }
     // Check type
-    guint8 firstByte = tvb_get_guint8(tvb, offset);
+    uint8_t firstByte = tvb_get_uint8(tvb, offset);
     if (firstByte > MAX_MATELINK_TYPE)
     {
         return 1;
     }
     // Check length
-    guint32 msglen = tvb_get_guint32(tvb, offset + 4, ENC_LITTLE_ENDIAN);
+    uint32_t msglen = tvb_get_uint32(tvb, offset + 4, ENC_LITTLE_ENDIAN);
     if (msglen < MATELINK_HDR_SIZE) {
         // The message is too small.
         return 1;
@@ -213,7 +213,7 @@ static guint32 test_matelink(tvbuff_t *tvb, packet_info* pinfo, int offset)
         // The message is too big.
         return 1;
     }
-    if ((guint32)remainingLength < msglen)
+    if ((uint32_t)remainingLength < msglen)
     {
         // Need more data to complete the message
         if (pinfo->can_desegment) {
@@ -231,7 +231,7 @@ static void dissect_matelink_hello(tvbuff_t * tvb, packet_info* pinfo _U_, proto
     col_set_str(pinfo->cinfo, COL_INFO, "Hello");
     // Header already dissected
 
-    gint size = 8;
+    int size = 8;
     proto_tree_add_item(tree, hf_matelink_hello_magic, tvb, offset, size, ENC_LITTLE_ENDIAN);
     offset += size;
     size = 8;
@@ -286,7 +286,7 @@ static void dissect_matelink_journalWrite(tvbuff_t * tvb, packet_info* pinfo _U_
 {
     col_set_str(pinfo->cinfo, COL_INFO, "JournalWrite");
     // Header already dissected
-    gint size = 4;
+    int size = 4;
     proto_tree_add_item(tree, hf_matelink_journalwrite_requestId, tvb, offset, size, ENC_LITTLE_ENDIAN);
     offset += size;
     size = 4;
@@ -294,7 +294,7 @@ static void dissect_matelink_journalWrite(tvbuff_t * tvb, packet_info* pinfo _U_
     offset += size;
     // The rest
     while (offset < len) {
-        guint32 curlen;
+        uint32_t curlen;
         size = 4;
         proto_tree_add_item_ret_uint(tree, hf_matelink_transheader_length, tvb, offset, size, ENC_LITTLE_ENDIAN, &curlen);
         proto_tree_add_item(tree, hf_matelink_transheader_type, tvb, offset, size, ENC_LITTLE_ENDIAN);
@@ -317,7 +317,7 @@ static void dissect_matelink_journalWriteAck(tvbuff_t * tvb, packet_info* pinfo 
 {
     col_set_str(pinfo->cinfo, COL_INFO, "JournalWriteAck");
     // Header already dissected
-    gint size = 4;
+    int size = 4;
     proto_tree_add_item(tree, hf_matelink_journalwriteack_requestId, tvb, offset, size, ENC_LITTLE_ENDIAN);
     offset += size;
     size = 4;
@@ -331,7 +331,7 @@ static void dissect_matelink_doorBell(tvbuff_t * tvb, packet_info* pinfo _U_, pr
 {
     col_set_str(pinfo->cinfo, COL_INFO, "DoorBell");
     // Header already dissected
-    gint size = 4;
+    int size = 4;
     proto_tree_add_item(tree, hf_matelink_doorbell_queueId, tvb, offset, size, ENC_LITTLE_ENDIAN);
     offset += size;
     size = 4;
@@ -344,7 +344,7 @@ static void dissect_matelink_SyncWrite(tvbuff_t * tvb, packet_info* pinfo _U_, p
 {
     col_set_str(pinfo->cinfo, COL_INFO, "SyncWrite");
     // Header already dissected
-    gint size = 4;
+    int size = 4;
     proto_tree_add_item(tree, hf_matelink_syncwrite_offset, tvb, offset, size, ENC_LITTLE_ENDIAN);
     offset += size;
     size = 4;
@@ -355,7 +355,7 @@ static void dissect_matelink_SyncWrite(tvbuff_t * tvb, packet_info* pinfo _U_, p
 }
 
 /* Determine the total length of an matelink packet, given the message header */
-static guint get_matelink_pdu_len(packet_info* inf, tvbuff_t *tvb, int offset, void *data _U_)
+static unsigned int get_matelink_pdu_len(packet_info* inf, tvbuff_t *tvb, int offset, void *data _U_)
 {
     /* msglen initialze to 1 because
      * if we return 0, it means the current PDU is deferred until we
@@ -364,7 +364,7 @@ static guint get_matelink_pdu_len(packet_info* inf, tvbuff_t *tvb, int offset, v
      * it means the current PDU is an error and we will be marked as error
      * and we move on to the next packet.
      */
-    guint32 msglen = test_matelink(tvb, inf, offset);
+    uint32_t msglen = test_matelink(tvb, inf, offset);
     return msglen;
 }
 
@@ -379,8 +379,8 @@ static int dissect_matelink_tcp_pdu(tvbuff_t *tvb, packet_info *pinfo,
     col_set_str(pinfo->cinfo, COL_PROTOCOL, "Matelink");
     col_clear(pinfo->cinfo, COL_INFO);
 
-    guint8 matelinktype = tvb_get_guint8(tvb, 0);
-    guint32 msglen = tvb_get_guint32(tvb, 4, ENC_LITTLE_ENDIAN);
+    uint8_t matelinktype = tvb_get_uint8(tvb, 0);
+    uint32_t msglen = tvb_get_uint32(tvb, 4, ENC_LITTLE_ENDIAN);
     ti = proto_tree_add_item(tree, proto_matelink, tvb, 0, msglen, ENC_LITTLE_ENDIAN);
     matelink_tree = proto_item_add_subtree(ti, ett_matelink);
 
@@ -392,7 +392,7 @@ static int dissect_matelink_tcp_pdu(tvbuff_t *tvb, packet_info *pinfo,
     offset += 1;
     proto_tree_add_item(matelink_tree, hf_matelink_pad0, tvb, offset, 2, ENC_LITTLE_ENDIAN);
     offset += 2;
-    guint32 len;
+    uint32_t len;
     proto_tree_add_item_ret_uint(matelink_tree, hf_matelink_len, tvb, offset, 4, ENC_LITTLE_ENDIAN, &len);
     offset += 4;
     proto_tree_add_item(matelink_tree, hf_matelink_seq, tvb, offset, 8, ENC_LITTLE_ENDIAN);
@@ -440,7 +440,7 @@ static int dissect_matelink(tvbuff_t *tvb, packet_info *pinfo, proto_tree *tree,
 
 void proto_reg_handoff_matelink(void)
 {
-    static gboolean inited = FALSE;
+    static bool inited = false;
         
 	if (!inited) {
         matelink_handle = create_dissector_handle(dissect_matelink, proto_matelink);
@@ -665,7 +665,7 @@ void proto_register_matelink(void)
     };
 
     /* Setup protocol subtree array */
-    static gint *ett[] =
+    static int *ett[] =
     {
         &ett_matelink,
     };

--- a/src/smf/packet-pubctrl.c
+++ b/src/smf/packet-pubctrl.c
@@ -29,8 +29,6 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include <glib.h>
-
 #include <epan/packet.h>
 #include <epan/prefs.h>
 
@@ -56,10 +54,10 @@ static int hf_pubctrl_platform_param = -1;
 static int hf_pubctrl_csmp_vrid_param = -1;
 
 /* Global sample preference ("controls" display of numbers) */
-//static gboolean gPREF_HEX = FALSE;
+//static bool gPREF_HEX = false;
 
 /* Initialize the subtree pointers */
-static gint ett_pubctrl = -1;
+static int ett_pubctrl = -1;
 
 #define PUBCTRL_UDP_PORT_PARAM 0x1
 #define PUBCTRL_EXPLICIT_ACK_MODE_PARAM 0x2
@@ -79,13 +77,13 @@ clientctrl_dissect_rtr_capabilities_param(
     	proto_tree *tree,
     	int offset,
     	int size,
-        gboolean extended);
+        bool extended);
 
 static void
 add_pubctrl_param(
     tvbuff_t *tvb,
     proto_tree *tree,
-    guint8 param_type,
+    uint8_t param_type,
     int offset,
     int size)
 {
@@ -97,53 +95,53 @@ add_pubctrl_param(
         case PUBCTRL_UDP_PORT_PARAM:
             proto_tree_add_item(tree,
                 hf_pubctrl_udp_port_param,
-                tvb, offset, size, FALSE);
+                tvb, offset, size, false);
             break;
 
         case PUBCTRL_EXPLICIT_ACK_MODE_PARAM:
             proto_tree_add_item(tree,
                 hf_pubctrl_explicit_ack_mode_param,
-                tvb, offset-2, size+2, FALSE);
+                tvb, offset-2, size+2, false);
             break;
 
         case PUBCTRL_UDP_SOURCE_ADDRESS_PARAM:
             proto_tree_add_item(tree,
                 hf_pubctrl_udp_source_addr_param,
-                tvb, offset, size, FALSE);
+                tvb, offset, size, false);
             break;
 
         case PUBCTRL_RTR_CAPABILITIES_PARAM:
-            clientctrl_dissect_rtr_capabilities_param(tvb, tree, offset, size, FALSE);
+            clientctrl_dissect_rtr_capabilities_param(tvb, tree, offset, size, false);
             break;
 
         case PUBCTRL_SOFTWARE_VERSION_PARAM:
             proto_tree_add_item(tree,
                 hf_pubctrl_software_version_param,
-                tvb, offset, size, FALSE);
+                tvb, offset, size, false);
             break;
 
         case PUBCTRL_SOFTWARE_DATE_PARAM:
             proto_tree_add_item(tree,
                 hf_pubctrl_software_date_param,
-                tvb, offset, size, FALSE);
+                tvb, offset, size, false);
             break;
 
         case PUBCTRL_PLATFORM_PARAM:
             proto_tree_add_item(tree,
                 hf_pubctrl_platform_param,
-                tvb, offset, size, FALSE);
+                tvb, offset, size, false);
             break;
 
 		case PUBCTRL_CSMP_VRID_PARAM:
             proto_tree_add_item(tree,
                 hf_pubctrl_csmp_vrid_param,
-                tvb, offset, size, FALSE);
+                tvb, offset, size, false);
             break;
 
         default:
             proto_tree_add_item(tree,
                 hf_pubctrl_unknown_param,
-                tvb, offset-2, size+2, FALSE);
+                tvb, offset-2, size+2, false);
             break;
     }
 }
@@ -155,18 +153,18 @@ dissect_pubctrl_param(
     proto_tree *tree)
 {
     int param_len;
-    guint8 param_type;
+    uint8_t param_type;
 
     /* Is it a pad byte? */
-    if (tvb_get_guint8(tvb, offset) == 0)
+    if (tvb_get_uint8(tvb, offset) == 0)
     {
         proto_tree_add_item(tree,
-            hf_pubctrl_pad_byte, tvb, offset, 1, FALSE);
+            hf_pubctrl_pad_byte, tvb, offset, 1, false);
         return 1;
     }
 
-    param_type = tvb_get_guint8(tvb, offset) & 0x1f;
-    param_len  = tvb_get_guint8(tvb, offset+1);
+    param_type = tvb_get_uint8(tvb, offset) & 0x1f;
+    param_len  = tvb_get_uint8(tvb, offset+1);
 
     add_pubctrl_param(tvb, tree, param_type, offset, param_len);
 
@@ -291,15 +289,15 @@ dissect_pubctrl(tvbuff_t *tvb, packet_info *pinfo _U_, proto_tree *tree, void* d
    offset to the end of the packet. */
 
 /* create display subtree for the protocol */
-		ti = proto_tree_add_item(tree, proto_pubctrl, tvb, 0, -1, FALSE);
+		ti = proto_tree_add_item(tree, proto_pubctrl, tvb, 0, -1, false);
 
 		pubctrl_tree = proto_item_add_subtree(ti, ett_pubctrl);
 
         /* Dissect header fields */
 		proto_tree_add_item(pubctrl_tree,
-		    hf_pubctrl_version, tvb, 0, 1, FALSE);
+		    hf_pubctrl_version, tvb, 0, 1, false);
         proto_tree_add_item(pubctrl_tree,
-            hf_pubctrl_msg_len, tvb, 1, 2, FALSE);
+            hf_pubctrl_msg_len, tvb, 1, 2, false);
 
         /* Dissect parameters */
         header_len = tvb_get_ntohs(tvb, 1) & 0xfff;
@@ -382,7 +380,7 @@ proto_register_pubctrl(void)
         	};
 
 /* Setup protocol subtree array */
-	static gint *ett[] = {
+	static int *ett[] = {
 		&ett_pubctrl
 	};
 
@@ -421,7 +419,7 @@ proto_register_pubctrl(void)
 void
 proto_reg_handoff_pubctrl(void)
 {
-	static gboolean inited = FALSE;
+	static bool inited = false;
         
 	if (!inited) {
 
@@ -430,7 +428,7 @@ proto_reg_handoff_pubctrl(void)
 	    (void)create_dissector_handle(dissect_pubctrl, proto_pubctrl);
 	    //dissector_add("smf.encap_proto", 0x8, pubctrl_handle);
         
-	    inited = TRUE;
+	    inited = true;
 	}
         
         /* 

--- a/src/smf/packet-smf-binarymeta.c
+++ b/src/smf/packet-smf-binarymeta.c
@@ -29,8 +29,6 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include <glib.h>
-
 #include <epan/packet.h>
 #include <epan/prefs.h>
 #include <epan/wmem_scopes.h>
@@ -51,10 +49,10 @@ static int hf_bm_sdtitem = -1;
 #define BM_TYPE_JMS 0x01
 
 /* Global sample preference ("controls" display of numbers) */
-//static gboolean gPREF_HEX = FALSE;
+//static bool gPREF_HEX = false;
 
 /* Initialize the subtree pointers */
-static gint ett_bm = -1;
+static int ett_bm = -1;
 
 typedef struct {
     int type;
@@ -91,18 +89,18 @@ dissect_bm(tvbuff_t *tvb, packet_info *pinfo, proto_tree *tree, void* data _U_)
    offset to the end of the packet. */
 
 /* create display subtree for the protocol */
-		ti = proto_tree_add_item(tree, proto_bm, tvb, 0, -1, FALSE);
+		ti = proto_tree_add_item(tree, proto_bm, tvb, 0, -1, false);
 
 		bm_tree = proto_item_add_subtree(ti, ett_bm);
 
         /* Dissect header fields */
 		proto_tree_add_item(bm_tree,
-		    hf_bm_num_elem, tvb, 0, 1, FALSE);
+		    hf_bm_num_elem, tvb, 0, 1, false);
 
 		/* Dissect contents */
-		num_blocks = tvb_get_guint8(tvb, 0);
+		num_blocks = tvb_get_uint8(tvb, 0);
 		for(i = 0; i < num_blocks; i++) {
-			idxblocks[i].type = tvb_get_guint8(tvb, 1+4*i);
+			idxblocks[i].type = tvb_get_uint8(tvb, 1+4*i);
 			idxblocks[i].length = tvb_get_ntoh24(tvb, 2+4*i);
 		}
 		data_offset = num_blocks * 4 + 1;
@@ -114,7 +112,7 @@ dissect_bm(tvbuff_t *tvb, packet_info *pinfo, proto_tree *tree, void* data _U_)
 			g_snprintf(buffer, 300, "Type %d Length %d", idxblocks[i].type, idxblocks[i].length);
 			proto_tree_add_string(bm_tree, hf_bm_block, tvb, cumul_offset, idxblocks[i].length, buffer);
 			if (idxblocks[i].type == BM_TYPE_SDT) {
-		            add_sdt_block(bm_tree, pinfo, hf_bm_sdtitem, tvb, cumul_offset, idxblocks[i].length, 1, FALSE);
+		            add_sdt_block(bm_tree, pinfo, hf_bm_sdtitem, tvb, cumul_offset, idxblocks[i].length, 1, false);
 			}
 			cumul_offset += idxblocks[i].length;
 		}
@@ -160,7 +158,7 @@ proto_register_bm(void)
 	};
 
 /* Setup protocol subtree array */
-	static gint *ett[] = {
+	static int *ett[] = {
 		&ett_bm
 	};
 
@@ -200,13 +198,13 @@ proto_register_bm(void)
 void
 proto_reg_handoff_bm(void)
 {
-	static gboolean inited = FALSE;
+	static bool inited = false;
 
 	if (!inited) {
 	    //dissector_handle_t bm_handle;
 	    //bm_handle = create_dissector_handle(dissect_bm, proto_bm);
 	    (void)create_dissector_handle(dissect_bm, proto_bm);
-	    inited = TRUE;
+	    inited = true;
 	}
 
         /*

--- a/src/smf/packet-smf-compress.c
+++ b/src/smf/packet-smf-compress.c
@@ -85,10 +85,10 @@ static voidpf stream_alloc(void * opaque, uInt num, uInt size)
     return wmem_alloc0(wmem_file_scope(), num*size);
 }
 
-static void stream_free(void * opaque, voidpf address)
+static void stream_free(void * opaque, voidpf stream_address)
 {
     (void)opaque; // avoid compiler warning
-    wmem_free(wmem_file_scope(), address);
+    wmem_free(wmem_file_scope(), stream_address);
 }
 
 static void init_stream(smf_compressed_stream_t *compressed_stream_p)

--- a/src/smf/packet-smf-compress.c
+++ b/src/smf/packet-smf-compress.c
@@ -40,7 +40,7 @@
 
 static int proto_smf_compressed = -1;
 static int global_smf_compressed_port = 55003;
-static guint dictionary_init = 0xee;
+static unsigned int dictionary_init = 0xee;
 static int hf_smf_compressed_segment_data = -1;
 
 static dissector_handle_t smf_tcp_compressed_handle;
@@ -49,7 +49,7 @@ static expert_field ei_decompression_error = EI_INIT;
 
 typedef struct _smf_uncompressed_buf_t {
     guchar *buf;
-    guint len;
+    unsigned int len;
     char *errorMsg;
 } smf_uncompressed_buf_t;
 
@@ -94,7 +94,7 @@ static void stream_free(void * opaque, voidpf address)
 static void init_stream(smf_compressed_stream_t *compressed_stream_p)
 {
     z_stream* stream_p = &compressed_stream_p->stream;
-    gint z_rc;
+    int z_rc;
     stream_p->next_in  = Z_NULL;
     stream_p->avail_in = 0;
     stream_p->zalloc   = stream_alloc;
@@ -116,9 +116,9 @@ static void init_stream(smf_compressed_stream_t *compressed_stream_p)
 }
 
 static void
-decompress_record(smf_compressed_stream_t* compressed_stream_p, const guchar* in, guint inl, guchar* out_str, guint* outl, char *errorMsg_p)
+decompress_record(smf_compressed_stream_t* compressed_stream_p, const guchar* in, unsigned int inl, guchar* out_str, unsigned int* outl, char *errorMsg_p)
 {
-    gint err = Z_OK;
+    int err = Z_OK;
 
     z_stream* stream_p = &compressed_stream_p->stream;
 DIAG_OFF(cast-qual)
@@ -206,7 +206,7 @@ static int dissect_smf_compressed(tvbuff_t *tvb, packet_info *pinfo, proto_tree 
     smf_uncompressed_buf_t *uncompressed_buf = NULL;
     if (!PINFO_FD_VISITED(pinfo)) {
         // First time decoding the frame
-        guint outl;
+        unsigned int outl;
         guchar out_str[MAX_DECOMPRESS_LEN];
         outl = MAX_DECOMPRESS_LEN;
         decompress_record(currentStream_p,
@@ -249,18 +249,18 @@ static int dissect_smf_compressed(tvbuff_t *tvb, packet_info *pinfo, proto_tree 
 
         // Save it so that we do not need to do uncompress when we revisit
         p_add_proto_data(wmem_file_scope(), pinfo, proto_smf_compressed,
-                (guint32)tvb_raw_offset(tvb), uncompressed_buf);
+                (uint32_t)tvb_raw_offset(tvb), uncompressed_buf);
 
     } else {
         uncompressed_buf = (smf_uncompressed_buf_t *)p_get_proto_data(wmem_file_scope(), pinfo,
-                proto_smf_compressed, (guint32)tvb_raw_offset(tvb));
+                proto_smf_compressed, (uint32_t)tvb_raw_offset(tvb));
         if (!uncompressed_buf) {
             // g_print("Cannot find previously parsed data - %d\n", tvb_raw_offset(tvb));
             return tvb_captured_length(tvb);
         }
     }
 
-    guint nbytes = uncompressed_buf->len;
+    unsigned int nbytes = uncompressed_buf->len;
     if (nbytes == 0) {
         // memory freed
         // This means we are reassembling in later frame
@@ -318,7 +318,7 @@ static int dissect_smf_compressed(tvbuff_t *tvb, packet_info *pinfo, proto_tree 
 
 void proto_reg_handoff_smf_compress(void)
 {
-    static gboolean inited = FALSE;
+    static bool inited = false;
         
 	if (!inited) {
         smf_tcp_compressed_handle = create_dissector_handle(dissect_smf_compressed, proto_smf_compressed);

--- a/src/smf/packet-smf-openmama-payload.c
+++ b/src/smf/packet-smf-openmama-payload.c
@@ -29,8 +29,6 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include <glib.h>
-
 #include <epan/packet.h>
 #include <epan/prefs.h>
 #include <epan/exceptions.h>
@@ -117,11 +115,11 @@ static int hf_mama_field_value_vector = -1;
 #define MAMA_PAYLOAD_SUBTAG_TYPE_FIELDNAME  101
 
 /* Initialize the subtree pointers */
-static gint ett_mama_payload = -1;
-static gint ett_mama_payload_field = -1;
-static gint ett_mama_payload_field_price = -1;
-static gint ett_mama_payload_field_vector = -1;
-static gint ett_mama_payload_field_datetime = -1;
+static int ett_mama_payload = -1;
+static int ett_mama_payload_field = -1;
+static int ett_mama_payload_field_price = -1;
+static int ett_mama_payload_field_vector = -1;
+static int ett_mama_payload_field_datetime = -1;
 
 static int
 dissect_mama_field_str(
@@ -130,22 +128,22 @@ dissect_mama_field_str(
     proto_tree *tree,
     packet_info *pinfo _U_)
 {
-    guint8 type;
-    guint32 value_len;
-    guint8 len_bytes;
+    uint8_t type;
+    uint32_t value_len;
+    uint8_t len_bytes;
     int loop;
 
     /* field name (optional) or field value */
-    type = tvb_get_guint8(tvb, offset);
+    type = tvb_get_uint8(tvb, offset);
 
     len_bytes = (type & SMF_PARAM_LENGTH_IN_BYTES_MASK) + 1 ;
     value_len = 0;
     for (loop=0; loop <len_bytes; loop++) {
-        value_len = (value_len << 8) +  tvb_get_guint8(tvb, offset + 1 +loop );
+        value_len = (value_len << 8) +  tvb_get_uint8(tvb, offset + 1 +loop );
     }
     value_len -= (len_bytes+1); /* */
 
-    proto_tree_add_item(tree, hf_mama_field_value_string, tvb, offset+len_bytes +1, value_len, FALSE);
+    proto_tree_add_item(tree, hf_mama_field_value_string, tvb, offset+len_bytes +1, value_len, false);
 
     return value_len + len_bytes +1;
 }
@@ -157,18 +155,18 @@ dissect_mama_field_msg(
     proto_tree *tree,
     packet_info *pinfo)
 {
-    guint8 type;
-    guint32 value_len;
-    guint8 len_bytes;
+    uint8_t type;
+    uint32_t value_len;
+    uint8_t len_bytes;
     tvbuff_t *next_tvb;
     int loop;
 
     /* field name (optional) or field value */
-    type = tvb_get_guint8(tvb, offset);
+    type = tvb_get_uint8(tvb, offset);
     len_bytes = (type & SMF_PARAM_LENGTH_IN_BYTES_MASK) + 1 ;
     value_len = 0;
     for (loop=0; loop <len_bytes; loop++) {
-        value_len = (value_len << 8) +  tvb_get_guint8(tvb, offset + 1 +loop );
+        value_len = (value_len << 8) +  tvb_get_uint8(tvb, offset + 1 +loop );
     }
     value_len -= (len_bytes+2);
 
@@ -186,7 +184,7 @@ dissect_vector_param(
     tvbuff_t *tvb,
     int offset,
     int value_len,
-    guint8 tag,
+    uint8_t tag,
     proto_tree *tree,
     packet_info *pinfo)
 {
@@ -196,7 +194,7 @@ dissect_vector_param(
     int count;
     int local_offset;
 
-    ti = proto_tree_add_item(tree, hf_mama_field_value_vector, tvb, offset, value_len, FALSE);
+    ti = proto_tree_add_item(tree, hf_mama_field_value_vector, tvb, offset, value_len, false);
     field_tree =   proto_item_add_subtree(ti, ett_mama_payload_field_vector);
 
     switch (tag) 
@@ -204,86 +202,86 @@ dissect_vector_param(
 
     case MAMA_PAYLOAD_SUBTAG_TYPE_BOOLEAN_VECTOR:
         for (loop =0; loop < value_len; loop++) {
-            proto_tree_add_item(field_tree, hf_mama_field_value_bool, tvb, offset+loop, 1, FALSE);
+            proto_tree_add_item(field_tree, hf_mama_field_value_bool, tvb, offset+loop, 1, false);
         }
         break;
     case MAMA_PAYLOAD_SUBTAG_TYPE_CHAR_VECTOR:
         for (loop =0; loop < (value_len/2); loop++) {
-            proto_tree_add_item(field_tree, hf_mama_field_value_char, tvb, offset+2*loop, 2, FALSE);
+            proto_tree_add_item(field_tree, hf_mama_field_value_char, tvb, offset+2*loop, 2, false);
         }
         break;
     case MAMA_PAYLOAD_SUBTAG_TYPE_INTEGER_1BYTE_VECTOR:
         for (loop =0; loop < value_len; loop++) {
-            proto_tree_add_item(field_tree, hf_mama_field_value_i8, tvb, offset+loop, 1, FALSE);
+            proto_tree_add_item(field_tree, hf_mama_field_value_i8, tvb, offset+loop, 1, false);
         }
         break;
     case MAMA_PAYLOAD_SUBTAG_TYPE_UNSIGNED_INTEGER_1BYTE_VECTOR:
         for (loop =0; loop < value_len; loop++) {
-            proto_tree_add_item(field_tree, hf_mama_field_value_u8, tvb, offset+loop, 1, FALSE);
+            proto_tree_add_item(field_tree, hf_mama_field_value_u8, tvb, offset+loop, 1, false);
         }
         break;
     case MAMA_PAYLOAD_SUBTAG_TYPE_INTEGER_2BYTE_VECTOR:
         for (loop =0; loop < (value_len/2); loop++) {
-            proto_tree_add_item(field_tree, hf_mama_field_value_i16, tvb, offset+2*loop, 2, FALSE);
+            proto_tree_add_item(field_tree, hf_mama_field_value_i16, tvb, offset+2*loop, 2, false);
         }
         break;
     case MAMA_PAYLOAD_SUBTAG_TYPE_UNSIGNED_INTEGER_2BYTE_VECTOR:
         for (loop =0; loop < (value_len/2); loop++) {
-            proto_tree_add_item(field_tree, hf_mama_field_value_u16, tvb, offset+2*loop, 2, FALSE);
+            proto_tree_add_item(field_tree, hf_mama_field_value_u16, tvb, offset+2*loop, 2, false);
         }
         break;
     case MAMA_PAYLOAD_SUBTAG_TYPE_INTEGER_4BYTE_VECTOR:
         for (loop =0; loop < (value_len/4); loop++) {
-            proto_tree_add_item(field_tree, hf_mama_field_value_i32, tvb, offset+4*loop, 4, FALSE);
+            proto_tree_add_item(field_tree, hf_mama_field_value_i32, tvb, offset+4*loop, 4, false);
         }
         break;
     case MAMA_PAYLOAD_SUBTAG_TYPE_UNSIGNED_INTEGER_4BYTE_VECTOR:
         for (loop =0; loop < (value_len/4); loop++) {
-            proto_tree_add_item(field_tree, hf_mama_field_value_u32, tvb, offset+4*loop, 4, FALSE);
+            proto_tree_add_item(field_tree, hf_mama_field_value_u32, tvb, offset+4*loop, 4, false);
         }
         break;
     case MAMA_PAYLOAD_SUBTAG_TYPE_INTEGER_8BYTE_VECTOR:
         for (loop =0; loop < (value_len/8); loop++) {
-            proto_tree_add_item(field_tree, hf_mama_field_value_i64, tvb, offset+8*loop, 8, FALSE);
+            proto_tree_add_item(field_tree, hf_mama_field_value_i64, tvb, offset+8*loop, 8, false);
         }
         break;
     case MAMA_PAYLOAD_SUBTAG_TYPE_UNSIGNED_INTEGER_8BYTE_VECTOR:
         for (loop =0; loop < (value_len/8); loop++) {
-            proto_tree_add_item(field_tree, hf_mama_field_value_u64, tvb, offset+8*loop, 8, FALSE);
+            proto_tree_add_item(field_tree, hf_mama_field_value_u64, tvb, offset+8*loop, 8, false);
         }
         break;
     case MAMA_PAYLOAD_SUBTAG_TYPE_FLOAT_4BYTE_VECTOR:
         for (loop =0; loop < (value_len/4); loop++) {
-            proto_tree_add_item(field_tree, hf_mama_field_value_f32, tvb, offset+4*loop, 4, FALSE);
+            proto_tree_add_item(field_tree, hf_mama_field_value_f32, tvb, offset+4*loop, 4, false);
         }
         break;
     case MAMA_PAYLOAD_SUBTAG_TYPE_FLOAT_8BYTE_VECTOR:
         for (loop =0; loop < (value_len/8); loop++) {
-            proto_tree_add_item(field_tree, hf_mama_field_value_f64, tvb, offset+8*loop, 8, FALSE);
+            proto_tree_add_item(field_tree, hf_mama_field_value_f64, tvb, offset+8*loop, 8, false);
         }
         break;
     case MAMA_PAYLOAD_SUBTAG_TYPE_DATETIME_VECTOR:
         for (loop =0; loop < (value_len/8); loop++) {
-            ti = proto_tree_add_item(field_tree, hf_mama_field_value_datetime, tvb, offset+8*loop, 8, FALSE);
+            ti = proto_tree_add_item(field_tree, hf_mama_field_value_datetime, tvb, offset+8*loop, 8, false);
             field_tree =   proto_item_add_subtree(ti, ett_mama_payload_field_datetime);
             proto_tree_add_item(field_tree,
-                hf_mama_field_value_datetime_seconds, tvb, offset+8*loop, 4, FALSE);
+                hf_mama_field_value_datetime_seconds, tvb, offset+8*loop, 4, false);
             proto_tree_add_item(field_tree,
-                hf_mama_field_value_datetime_precision, tvb, offset+8*loop+4, 1, FALSE); 
+                hf_mama_field_value_datetime_precision, tvb, offset+8*loop+4, 1, false); 
             proto_tree_add_item(field_tree,
-                hf_mama_field_value_datetime_hints, tvb, offset+8*loop+4, 1, FALSE); 
+                hf_mama_field_value_datetime_hints, tvb, offset+8*loop+4, 1, false); 
             proto_tree_add_item(field_tree,
-                hf_mama_field_value_datetime_microseconds, tvb, offset+8*loop+5, 3, FALSE); 
+                hf_mama_field_value_datetime_microseconds, tvb, offset+8*loop+5, 3, false); 
         }
         break;
     case MAMA_PAYLOAD_SUBTAG_TYPE_PRICE_VECTOR:
         for (loop =0; loop < (value_len/9); loop++) {
-            ti = proto_tree_add_item(field_tree, hf_mama_field_value_price, tvb, offset+9*loop, 9, FALSE);
+            ti = proto_tree_add_item(field_tree, hf_mama_field_value_price, tvb, offset+9*loop, 9, false);
             field_tree =   proto_item_add_subtree(ti, ett_mama_payload_field_price);
             proto_tree_add_item(field_tree,
-                hf_mama_field_value_price_f64, tvb, offset+9*loop, 8, FALSE);
+                hf_mama_field_value_price_f64, tvb, offset+9*loop, 8, false);
             proto_tree_add_item(field_tree,
-                hf_mama_field_value_price_u8, tvb, offset+9*loop+8, 1, FALSE);	
+                hf_mama_field_value_price_u8, tvb, offset+9*loop+8, 1, false);	
         }
         break;
 
@@ -312,7 +310,7 @@ dissect_byte_array_param(
     tvbuff_t *tvb,
     int offset,
     int value_len,
-    guint8 tag,
+    uint8_t tag,
     proto_tree *tree,
     packet_info *pinfo)
 {
@@ -331,28 +329,28 @@ dissect_byte_array_param(
         break;
     case MAMA_PAYLOAD_SUBTAG_TYPE_OPAQUE:
         proto_tree_add_item(tree,
-            hf_mama_field_value_opaque, tvb, offset, value_len, FALSE);
+            hf_mama_field_value_opaque, tvb, offset, value_len, false);
         break;
     case MAMA_PAYLOAD_SUBTAG_TYPE_DATETIME:
-        ti = proto_tree_add_item(tree, hf_mama_field_value_datetime, tvb, offset, value_len, FALSE);
+        ti = proto_tree_add_item(tree, hf_mama_field_value_datetime, tvb, offset, value_len, false);
         field_tree =   proto_item_add_subtree(ti, ett_mama_payload_field_datetime);
         proto_tree_add_item(field_tree,
-            hf_mama_field_value_datetime_seconds, tvb, offset, 4, FALSE);
+            hf_mama_field_value_datetime_seconds, tvb, offset, 4, false);
         proto_tree_add_item(field_tree,
-            hf_mama_field_value_datetime_precision, tvb, offset+4, 1, FALSE); 
+            hf_mama_field_value_datetime_precision, tvb, offset+4, 1, false); 
         proto_tree_add_item(field_tree,
-            hf_mama_field_value_datetime_hints, tvb, offset+4, 1, FALSE); 
+            hf_mama_field_value_datetime_hints, tvb, offset+4, 1, false); 
         proto_tree_add_item(field_tree,
-            hf_mama_field_value_datetime_microseconds, tvb, offset+5, 3, FALSE); 
+            hf_mama_field_value_datetime_microseconds, tvb, offset+5, 3, false); 
         break;
     case MAMA_PAYLOAD_SUBTAG_TYPE_PRICE:
         ti = proto_tree_add_item(tree,
-            hf_mama_field_value_price, tvb, offset, value_len, FALSE);
+            hf_mama_field_value_price, tvb, offset, value_len, false);
         field_tree =   proto_item_add_subtree(ti, ett_mama_payload_field_price);
         proto_tree_add_item(field_tree,
-            hf_mama_field_value_price_f64, tvb, offset, 8, FALSE);
+            hf_mama_field_value_price_f64, tvb, offset, 8, false);
         proto_tree_add_item(field_tree,
-            hf_mama_field_value_price_u8, tvb, offset+8, 1, FALSE);
+            hf_mama_field_value_price_u8, tvb, offset+8, 1, false);
         break;
 
     case MAMA_PAYLOAD_SUBTAG_TYPE_BOOLEAN_VECTOR:
@@ -384,40 +382,40 @@ static int mama_field_length(
     int offset)
 {
     int field_len = 0;
-    guint8 tag;
-    guint8 param_type;
-    guint32 param_value_len;
-    guint8 param_len_bytes;
+    uint8_t tag;
+    uint8_t param_type;
+    uint32_t param_value_len;
+    uint8_t param_len_bytes;
     int loop;
 
     /* field id*/
     field_len =4;
 
     /* field name (optional) or field value */
-    param_type = tvb_get_guint8(tvb, offset+field_len);
+    param_type = tvb_get_uint8(tvb, offset+field_len);
     field_len++;
     param_len_bytes = (param_type & SMF_PARAM_LENGTH_IN_BYTES_MASK) + 1 ;
     param_value_len = 0;
     for (loop=0; loop <param_len_bytes; loop++) {
-        param_value_len = (param_value_len << 8) +  tvb_get_guint8(tvb, offset + field_len+loop );
+        param_value_len = (param_value_len << 8) +  tvb_get_uint8(tvb, offset + field_len+loop );
     }
     param_value_len -= (param_len_bytes+1); /* */
     field_len += param_len_bytes;
 
     /*  check for optional field name  */
     if ( (param_type & SMF_PARAM_MASK)  == SMF_PARAM_TYPE_BYTE_ARRAY  ) {
-        tag = tvb_get_guint8(tvb, offset + field_len );
+        tag = tvb_get_uint8(tvb, offset + field_len );
         /* check for field name */
         if (tag == MAMA_PAYLOAD_SUBTAG_TYPE_FIELDNAME) {
             field_len++;
             param_value_len--;
             field_len += param_value_len;
-            param_type = tvb_get_guint8(tvb, offset + field_len);
+            param_type = tvb_get_uint8(tvb, offset + field_len);
             field_len++;
             param_len_bytes = (param_type & SMF_PARAM_LENGTH_IN_BYTES_MASK) +1;
             param_value_len = 0;
             for (loop=0; loop <param_len_bytes; loop++) {
-                param_value_len = (param_value_len << 8) +  tvb_get_guint8(tvb, offset + field_len+loop );
+                param_value_len = (param_value_len << 8) +  tvb_get_uint8(tvb, offset + field_len+loop );
             }
             param_value_len -= (param_len_bytes+1);
             field_len += param_len_bytes;
@@ -428,7 +426,7 @@ static int mama_field_length(
     switch (param_type & SMF_PARAM_MASK)
     {
     case SMF_PARAM_TYPE_BYTE_ARRAY:
-        tag=tvb_get_guint8(tvb, offset + field_len );
+        tag=tvb_get_uint8(tvb, offset + field_len );
         field_len++;
         param_value_len--;
         break;
@@ -447,50 +445,50 @@ dissect_mama_field(
     packet_info *pinfo)
 {
     int field_len = 0;
-    guint8 tag;
-    guint8 param_type;
-    guint32 param_value_len;
-    guint8 param_len_bytes;
+    uint8_t tag;
+    uint8_t param_type;
+    uint32_t param_value_len;
+    uint8_t param_len_bytes;
     int loop;
     proto_tree   *field_tree;
     proto_item   *ti;
     field_len = mama_field_length(tvb, offset);
-    ti = proto_tree_add_item(tree, hf_mama_payload_field, tvb, offset, field_len, FALSE);
+    ti = proto_tree_add_item(tree, hf_mama_payload_field, tvb, offset, field_len, false);
     field_tree =   proto_item_add_subtree(ti, ett_mama_payload_field);
 
     /* field id: skip the 1st 2 bytes */
     field_len =2;
     proto_tree_add_item(field_tree,
-        hf_mama_field_id, tvb, offset+field_len, 2, FALSE);
+        hf_mama_field_id, tvb, offset+field_len, 2, false);
     field_len +=2;
 
     /* field name (optional) or field value */
-    param_type = tvb_get_guint8(tvb, offset+field_len);
+    param_type = tvb_get_uint8(tvb, offset+field_len);
     field_len++;
     param_len_bytes = (param_type & SMF_PARAM_LENGTH_IN_BYTES_MASK) + 1 ;
     param_value_len = 0;
     for (loop=0; loop <param_len_bytes; loop++) {
-        param_value_len = (param_value_len << 8) +  tvb_get_guint8(tvb, offset + field_len+loop );
+        param_value_len = (param_value_len << 8) +  tvb_get_uint8(tvb, offset + field_len+loop );
     }
     param_value_len -= (param_len_bytes+1); /* */
     field_len += param_len_bytes;
 
     /*  check for optional field name  */
     if ( (param_type & SMF_PARAM_MASK)  == SMF_PARAM_TYPE_BYTE_ARRAY  ) {
-        tag = tvb_get_guint8(tvb, offset + field_len );
+        tag = tvb_get_uint8(tvb, offset + field_len );
         /* check for field name */
         if (tag == MAMA_PAYLOAD_SUBTAG_TYPE_FIELDNAME) {
             field_len++;
             param_value_len--;
             proto_tree_add_item(field_tree,
-                hf_mama_field_name, tvb, offset+field_len, param_value_len, FALSE);
+                hf_mama_field_name, tvb, offset+field_len, param_value_len, false);
             field_len += param_value_len;
-            param_type = tvb_get_guint8(tvb, offset + field_len);
+            param_type = tvb_get_uint8(tvb, offset + field_len);
             field_len++;
             param_len_bytes = (param_type & SMF_PARAM_LENGTH_IN_BYTES_MASK) +1;
             param_value_len = 0;
             for (loop=0; loop <param_len_bytes; loop++) {
-                param_value_len = (param_value_len << 8) +  tvb_get_guint8(tvb, offset + field_len+loop );
+                param_value_len = (param_value_len << 8) +  tvb_get_uint8(tvb, offset + field_len+loop );
             }
             param_value_len -= (param_len_bytes+1);
             field_len += param_len_bytes;
@@ -501,24 +499,24 @@ dissect_mama_field(
     switch (param_type & SMF_PARAM_MASK)
     {
     case SMF_PARAM_TYPE_BOOLEAN:
-        proto_tree_add_item(field_tree, hf_mama_field_value_bool, tvb, offset+field_len, param_value_len, FALSE);
+        proto_tree_add_item(field_tree, hf_mama_field_value_bool, tvb, offset+field_len, param_value_len, false);
         break;
 
     case SMF_PARAM_TYPE_INTEGER:
         switch (param_value_len)
         {
         case 1:
-            proto_tree_add_item(field_tree, hf_mama_field_value_i8, tvb, offset+field_len, param_value_len, FALSE);
+            proto_tree_add_item(field_tree, hf_mama_field_value_i8, tvb, offset+field_len, param_value_len, false);
             break;
         case 2:
-            proto_tree_add_item(field_tree, hf_mama_field_value_i16, tvb, offset+field_len, param_value_len, FALSE);
+            proto_tree_add_item(field_tree, hf_mama_field_value_i16, tvb, offset+field_len, param_value_len, false);
             break;
         case 4:
-            proto_tree_add_item(field_tree, hf_mama_field_value_i32, tvb, offset+field_len, param_value_len, FALSE);
+            proto_tree_add_item(field_tree, hf_mama_field_value_i32, tvb, offset+field_len, param_value_len, false);
             break;		
         case 8:
         default:
-            proto_tree_add_item(field_tree, hf_mama_field_value_i64, tvb, offset+field_len, param_value_len, FALSE);
+            proto_tree_add_item(field_tree, hf_mama_field_value_i64, tvb, offset+field_len, param_value_len, false);
             break;
         }
         break;
@@ -526,41 +524,41 @@ dissect_mama_field(
         switch (param_value_len)
         {
         case 1:
-            proto_tree_add_item(field_tree, hf_mama_field_value_u8, tvb, offset+field_len, param_value_len, FALSE);
+            proto_tree_add_item(field_tree, hf_mama_field_value_u8, tvb, offset+field_len, param_value_len, false);
             break;
         case 2:
-            proto_tree_add_item(field_tree, hf_mama_field_value_u16, tvb, offset+field_len, param_value_len, FALSE);
+            proto_tree_add_item(field_tree, hf_mama_field_value_u16, tvb, offset+field_len, param_value_len, false);
             break;
         case 4:
-            proto_tree_add_item(field_tree, hf_mama_field_value_u32, tvb, offset+field_len, param_value_len, FALSE);
+            proto_tree_add_item(field_tree, hf_mama_field_value_u32, tvb, offset+field_len, param_value_len, false);
             break;		
         case 8:
         default:
-            proto_tree_add_item(field_tree, hf_mama_field_value_u64, tvb, offset+field_len, param_value_len, FALSE);
+            proto_tree_add_item(field_tree, hf_mama_field_value_u64, tvb, offset+field_len, param_value_len, false);
             break;
         }
         break;
     case SMF_PARAM_TYPE_FLOAT:
         if (param_value_len == 4) {
-            proto_tree_add_item(field_tree, hf_mama_field_value_f32, tvb, offset+field_len, param_value_len, FALSE);
+            proto_tree_add_item(field_tree, hf_mama_field_value_f32, tvb, offset+field_len, param_value_len, false);
         }
         else {
-            proto_tree_add_item(field_tree, hf_mama_field_value_f64, tvb, offset+field_len, param_value_len, FALSE);
+            proto_tree_add_item(field_tree, hf_mama_field_value_f64, tvb, offset+field_len, param_value_len, false);
         }
         break;
     case SMF_PARAM_TYPE_CHAR:
-        proto_tree_add_item(field_tree, hf_mama_field_value_char, tvb, offset+field_len, param_value_len, FALSE);
+        proto_tree_add_item(field_tree, hf_mama_field_value_char, tvb, offset+field_len, param_value_len, false);
         break;
 
     case SMF_PARAM_TYPE_BYTE_ARRAY:
-        tag=tvb_get_guint8(tvb, offset + field_len );
+        tag=tvb_get_uint8(tvb, offset + field_len );
         field_len++;
         param_value_len--;
         dissect_byte_array_param(tvb, offset+field_len, param_value_len, tag, field_tree, pinfo);	
         break;
 
     case SMF_PARAM_TYPE_STRING:
-        proto_tree_add_item(field_tree, hf_mama_field_value_string, tvb, offset+field_len, param_value_len, FALSE);
+        proto_tree_add_item(field_tree, hf_mama_field_value_string, tvb, offset+field_len, param_value_len, false);
         break;
     case SMF_PARAM_TYPE_DESTINATION:
     case SMF_PARAM_TYPE_SMF_MSG:
@@ -600,18 +598,18 @@ dissect_mama_payload(tvbuff_t *tvb, packet_info *pinfo, proto_tree *tree, void* 
     int stream_len;
 
     /* create display subtree for the protocol */
-    ti = proto_tree_add_item(tree, proto_mama_payload, tvb, 0, -1, FALSE);
+    ti = proto_tree_add_item(tree, proto_mama_payload, tvb, 0, -1, false);
     payload_tree = proto_item_add_subtree(ti, ett_mama_payload);
 
     stream_len = tvb_get_ntohl(tvb, 3);
     proto_tree_add_item(payload_tree,
-        hf_mama_payload_type, tvb, 0, 1, FALSE);
+        hf_mama_payload_type, tvb, 0, 1, false);
 
     proto_tree_add_item(payload_tree,
-        hf_mama_payload_version, tvb, 1, 1, FALSE);
+        hf_mama_payload_version, tvb, 1, 1, false);
 
     proto_tree_add_item(payload_tree,
-        hf_mama_stream_length, tvb, 3, 4, FALSE);
+        hf_mama_stream_length, tvb, 3, 4, false);
 
     dissect_mama_fields(tvb, 7, stream_len-5, payload_tree, pinfo); 
 
@@ -724,7 +722,7 @@ proto_register_mama_payload(void)
     };
 
     /* Setup protocol subtree array */
-    static gint *ett[] = {
+    static int *ett[] = {
         &ett_mama_payload,
         &ett_mama_payload_field,
         &ett_mama_payload_field_price,
@@ -757,11 +755,11 @@ proto_register_mama_payload(void)
 void
 proto_reg_handoff_mama_payload(void)
 {
-    static gboolean inited = FALSE;
+    static bool inited = false;
 
     if (!inited) {
         mama_payload_handle = create_dissector_handle(dissect_mama_payload, proto_mama_payload);
-        inited = TRUE;
+        inited = true;
     }
 }
 

--- a/src/smf/packet-smp.c
+++ b/src/smf/packet-smp.c
@@ -29,8 +29,6 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include <glib.h>
-
 #include <epan/packet.h>
 #include <epan/prefs.h>
 
@@ -59,10 +57,10 @@ static int hf_smp_add_queuename = -1;
 static int hf_smp_add_clientname = -1;
 
 /* Global sample preference ("controls" display of numbers) */
-//static gboolean gPREF_HEX = FALSE;
+//static bool gPREF_HEX = false;
 
 /* Initialize the subtree pointers */
-static gint ett_smp = -1;
+static int ett_smp = -1;
 
 #define SMP_ADDSUBSCRIPTION 0x00
 #define SMP_REMSUBSCRIPTION 0x01
@@ -88,15 +86,15 @@ static void dissect_smp_flags(
 	proto_tree *tree)
 {
 	proto_tree_add_item(tree,
-	    hf_smp_add_da, tvb, offset, 1, FALSE);
+	    hf_smp_add_da, tvb, offset, 1, false);
 	proto_tree_add_item(tree,
-	    hf_smp_add_r, tvb, offset, 1, FALSE);
+	    hf_smp_add_r, tvb, offset, 1, false);
 	proto_tree_add_item(tree,
-	    hf_smp_add_t, tvb, offset, 1, FALSE);
+	    hf_smp_add_t, tvb, offset, 1, false);
 	proto_tree_add_item(tree,
-	    hf_smp_add_p, tvb, offset, 1, FALSE);
+	    hf_smp_add_p, tvb, offset, 1, false);
 	proto_tree_add_item(tree,
-	    hf_smp_add_f, tvb, offset, 1, FALSE);
+	    hf_smp_add_f, tvb, offset, 1, false);
 
 }
 
@@ -110,7 +108,7 @@ static void dissect_smp_add_remove(
 	dissect_smp_flags(tvb, offset, tree);
 	offset++;
 	proto_tree_add_item(tree,
-	    hf_smp_add_subscription, tvb, offset, offset_end - offset, FALSE);
+	    hf_smp_add_subscription, tvb, offset, offset_end - offset, false);
 }
 
 static void dissect_smp_add_remove_queue_sub(
@@ -125,15 +123,15 @@ static void dissect_smp_add_remove_queue_sub(
 	dissect_smp_flags(tvb, offset, tree);
 	offset++;
 
-	qn_len = tvb_get_guint8(tvb, offset);
+	qn_len = tvb_get_uint8(tvb, offset);
 	offset++;
 	proto_tree_add_item(tree,
-	    hf_smp_add_queuename, tvb, offset, qn_len, FALSE);
+	    hf_smp_add_queuename, tvb, offset, qn_len, false);
 	offset += qn_len;
-	sn_len = tvb_get_guint8(tvb, offset);
+	sn_len = tvb_get_uint8(tvb, offset);
 	offset++;
 	proto_tree_add_item(tree,
-	    hf_smp_add_subscription, tvb, offset, sn_len, FALSE);
+	    hf_smp_add_subscription, tvb, offset, sn_len, false);
 	
 
 }
@@ -150,15 +148,15 @@ static void dissect_smp_add_remove_clientname(
 	dissect_smp_flags(tvb, offset, tree);
 	offset++;
 
-	cn_len = tvb_get_guint8(tvb, offset);
+	cn_len = tvb_get_uint8(tvb, offset);
 	offset++;
 	proto_tree_add_item(tree,
-	    hf_smp_add_clientname, tvb, offset, cn_len, FALSE);
+	    hf_smp_add_clientname, tvb, offset, cn_len, false);
 	offset += cn_len;
-	sn_len = tvb_get_guint8(tvb, offset);
+	sn_len = tvb_get_uint8(tvb, offset);
 	offset++;
 	proto_tree_add_item(tree,
-	    hf_smp_add_subscription, tvb, offset, sn_len, FALSE);
+	    hf_smp_add_subscription, tvb, offset, sn_len, false);
 	
 
 }
@@ -267,21 +265,21 @@ dissect_smp(tvbuff_t *tvb, packet_info *pinfo _U_, proto_tree *tree, void *data)
    offset to the end of the packet. */
 
 /* create display subtree for the protocol */
-		ti = proto_tree_add_item(tree, proto_smp, tvb, 0, -1, FALSE);
+		ti = proto_tree_add_item(tree, proto_smp, tvb, 0, -1, false);
 
 		smp_tree = proto_item_add_subtree(ti, ett_smp);
 
         /* Dissect header fields */
 		proto_tree_add_item(smp_tree,
-		    hf_smp_uh, tvb, 0, 1, FALSE);
+		    hf_smp_uh, tvb, 0, 1, false);
         proto_tree_add_item(smp_tree,
-            hf_smp_msg_type, tvb, 0, 1, FALSE);
+            hf_smp_msg_type, tvb, 0, 1, false);
         proto_tree_add_item(smp_tree,
-            hf_smp_msg_len, tvb, 1, 4, FALSE);
+            hf_smp_msg_len, tvb, 1, 4, false);
 
 		/* Dissect contents */
 		msg_len = tvb_get_ntohl(tvb, 1);
-		msg_type = tvb_get_guint8(tvb, 0) & 0x7f;
+		msg_type = tvb_get_uint8(tvb, 0) & 0x7f;
 		switch(msg_type)
 		{
 		case SMP_ADDSUBSCRIPTION:
@@ -298,7 +296,7 @@ dissect_smp(tvbuff_t *tvb, packet_info *pinfo _U_, proto_tree *tree, void *data)
 			break;
 		default:
 			proto_tree_add_item(smp_tree,
-				hf_smp_payload, tvb, 5, msg_len-5, FALSE);
+				hf_smp_payload, tvb, 5, msg_len-5, false);
 			break;
 		}
 
@@ -307,7 +305,7 @@ dissect_smp(tvbuff_t *tvb, packet_info *pinfo _U_, proto_tree *tree, void *data)
 //        dissect_assuredctrl_params(tvb, 3, 4*header_len, assuredctrl_tree);
 
 		/* Figure out type of message and put it on the shared parent info */
-		msgtype = (tvb_get_guint8(tvb, 0) & 0x7f);
+		msgtype = (tvb_get_uint8(tvb, 0) & 0x7f);
 		str_msgtype = try_val_to_str(msgtype, msgtypenames);
 
 		if (str_msgtype) {
@@ -399,7 +397,7 @@ proto_register_smp(void)
 	};
 
 /* Setup protocol subtree array */
-	static gint *ett[] = {
+	static int *ett[] = {
 		&ett_smp
 	};
 
@@ -439,13 +437,13 @@ proto_register_smp(void)
 void
 proto_reg_handoff_smp(void)
 {
-	static gboolean inited = FALSE;
+	static bool inited = false;
         
 	if (!inited) {
 	    //dissector_handle_t smp_handle;
 	    //smp_handle = create_dissector_handle(dissect_smp, proto_smp);        
 	    (void)create_dissector_handle(dissect_smp, proto_smp);
-	    inited = TRUE;
+	    inited = true;
 	}
         
         /* 

--- a/src/smf/packet-smrp.c
+++ b/src/smf/packet-smrp.c
@@ -29,8 +29,6 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include <glib.h>
-
 #include <epan/packet.h>
 #include <epan/prefs.h>
 
@@ -105,10 +103,10 @@ static int hf_smrp_parm_subs_info_topic_string = -1;
 static int hf_smrp_parm_unknown = -1;
      
 /* Global sample preference ("controls" display of numbers) */
-//static gboolean gPREF_HEX = FALSE;
+//static bool gPREF_HEX = false;
 
 /* Initialize the subtree pointers */
-static gint ett_smrp = -1;
+static int ett_smrp = -1;
 
 #define SMRP_MSG_HEADER_LEN          36
 #define SMRP_DB_SUMMARY_MSG          0x00
@@ -138,12 +136,12 @@ dissect_db_summary(tvbuff_t *tvb, packet_info *pinfo _U_, proto_tree *smrp_tree,
 
   if (tvb_captured_length_remaining(tvb, offset) < 12) return -1;
 
-  proto_tree_add_item(smrp_tree, hf_smrp_db_summary_cs_flag, tvb, offset, 2, FALSE);
-  proto_tree_add_item(smrp_tree, hf_smrp_db_summary_rfu, tvb, offset, 2, FALSE);
-  proto_tree_add_item(smrp_tree, hf_smrp_db_summary_rq_flag, tvb, offset, 2, FALSE);
-  proto_tree_add_item(smrp_tree, hf_smrp_db_summary_num_blocks_in_db, tvb, offset+2, 2, FALSE);
-  proto_tree_add_item(smrp_tree, hf_smrp_db_summary_block_summary_cs, tvb, offset+4, 4, FALSE);
-  proto_tree_add_item(smrp_tree, hf_smrp_db_summary_num_subs_in_db, tvb, offset+8, 4, FALSE);
+  proto_tree_add_item(smrp_tree, hf_smrp_db_summary_cs_flag, tvb, offset, 2, false);
+  proto_tree_add_item(smrp_tree, hf_smrp_db_summary_rfu, tvb, offset, 2, false);
+  proto_tree_add_item(smrp_tree, hf_smrp_db_summary_rq_flag, tvb, offset, 2, false);
+  proto_tree_add_item(smrp_tree, hf_smrp_db_summary_num_blocks_in_db, tvb, offset+2, 2, false);
+  proto_tree_add_item(smrp_tree, hf_smrp_db_summary_block_summary_cs, tvb, offset+4, 4, false);
+  proto_tree_add_item(smrp_tree, hf_smrp_db_summary_num_subs_in_db, tvb, offset+8, 4, false);
   *offset_ptr = offset+12;
 
   return 0;
@@ -161,7 +159,7 @@ dissect_block_summary(tvbuff_t *tvb, packet_info *pinfo, proto_tree *smrp_tree, 
   int offset = *offset_ptr;
   if (tvb_captured_length_remaining(tvb, offset) < 8) return -1;
 
-  proto_tree_add_item(smrp_tree, hf_smrp_block_summary_rfu, tvb, offset, 8, FALSE);
+  proto_tree_add_item(smrp_tree, hf_smrp_block_summary_rfu, tvb, offset, 8, false);
   *offset_ptr = offset+8;
 
   return 0;
@@ -176,20 +174,20 @@ dissect_block_contents(tvbuff_t *tvb, packet_info *pinfo _U_, proto_tree *smrp_t
 
   if (tvb_captured_length_remaining(tvb, offset) < 48) return -1;
 
-  proto_tree_add_item(smrp_tree, hf_smrp_block_contents_block_id, tvb, offset, 4, FALSE);
-  proto_tree_add_item(smrp_tree, hf_smrp_block_contents_seq_num, tvb, offset+4, 4, FALSE);
-  proto_tree_add_item(smrp_tree, hf_smrp_block_contents_block_key, tvb, offset+8, 8, FALSE);
-  proto_tree_add_item(smrp_tree, hf_smrp_block_contents_block_cs, tvb, offset+16, 4, FALSE);
-  proto_tree_add_item(smrp_tree, hf_smrp_block_contents_flags, tvb, offset+20, 2, FALSE);
-  proto_tree_add_item(smrp_tree, hf_smrp_block_contents_flags_cs, tvb, offset+20, 2, FALSE);
-  proto_tree_add_item(smrp_tree, hf_smrp_block_contents_flags_rfu0, tvb, offset+20, 2, FALSE);
-  proto_tree_add_item(smrp_tree, hf_smrp_block_contents_flags_p, tvb, offset+20, 2, FALSE);
-  proto_tree_add_item(smrp_tree, hf_smrp_block_contents_flags_rfu1, tvb, offset+20, 2, FALSE);
-  proto_tree_add_item(smrp_tree, hf_smrp_block_contents_flags_u, tvb, offset+20, 2, FALSE);
-  proto_tree_add_item(smrp_tree, hf_smrp_block_contents_flags_rfu2, tvb, offset+20, 2, FALSE);
-  proto_tree_add_item(smrp_tree, hf_smrp_block_contents_num_subs_in_block, tvb, offset+22, 2, FALSE);
-  proto_tree_add_item(smrp_tree, hf_smrp_block_contents_msg_vpn_hash, tvb, offset+24, 8, FALSE);
-  proto_tree_add_item(smrp_tree, hf_smrp_block_contents_rfu, tvb, offset+32, 16, FALSE);
+  proto_tree_add_item(smrp_tree, hf_smrp_block_contents_block_id, tvb, offset, 4, false);
+  proto_tree_add_item(smrp_tree, hf_smrp_block_contents_seq_num, tvb, offset+4, 4, false);
+  proto_tree_add_item(smrp_tree, hf_smrp_block_contents_block_key, tvb, offset+8, 8, false);
+  proto_tree_add_item(smrp_tree, hf_smrp_block_contents_block_cs, tvb, offset+16, 4, false);
+  proto_tree_add_item(smrp_tree, hf_smrp_block_contents_flags, tvb, offset+20, 2, false);
+  proto_tree_add_item(smrp_tree, hf_smrp_block_contents_flags_cs, tvb, offset+20, 2, false);
+  proto_tree_add_item(smrp_tree, hf_smrp_block_contents_flags_rfu0, tvb, offset+20, 2, false);
+  proto_tree_add_item(smrp_tree, hf_smrp_block_contents_flags_p, tvb, offset+20, 2, false);
+  proto_tree_add_item(smrp_tree, hf_smrp_block_contents_flags_rfu1, tvb, offset+20, 2, false);
+  proto_tree_add_item(smrp_tree, hf_smrp_block_contents_flags_u, tvb, offset+20, 2, false);
+  proto_tree_add_item(smrp_tree, hf_smrp_block_contents_flags_rfu2, tvb, offset+20, 2, false);
+  proto_tree_add_item(smrp_tree, hf_smrp_block_contents_num_subs_in_block, tvb, offset+22, 2, false);
+  proto_tree_add_item(smrp_tree, hf_smrp_block_contents_msg_vpn_hash, tvb, offset+24, 8, false);
+  proto_tree_add_item(smrp_tree, hf_smrp_block_contents_rfu, tvb, offset+32, 16, false);
   *offset_ptr = offset+48;
 
   return 0;
@@ -208,11 +206,11 @@ dissect_block_update(tvbuff_t *tvb, packet_info *pinfo, proto_tree *smrp_tree, i
   // Next dissect the  Block Update Header
   if (tvb_captured_length_remaining(tvb, offset) < 24) return -1;
 
-  proto_tree_add_item(smrp_tree, hf_smrp_block_update_pu, tvb, offset, 4, FALSE);
-  proto_tree_add_item(smrp_tree, hf_smrp_block_update_rfu0, tvb, offset, 4, FALSE);
-  proto_tree_add_item(smrp_tree, hf_smrp_block_update_num_adds_in_update, tvb, offset+4, 2, FALSE);
-  proto_tree_add_item(smrp_tree, hf_smrp_block_update_num_removes_in_update, tvb, offset+6, 2, FALSE);
-  proto_tree_add_item(smrp_tree, hf_smrp_block_update_rfu1, tvb, offset+8, 16, FALSE);
+  proto_tree_add_item(smrp_tree, hf_smrp_block_update_pu, tvb, offset, 4, false);
+  proto_tree_add_item(smrp_tree, hf_smrp_block_update_rfu0, tvb, offset, 4, false);
+  proto_tree_add_item(smrp_tree, hf_smrp_block_update_num_adds_in_update, tvb, offset+4, 2, false);
+  proto_tree_add_item(smrp_tree, hf_smrp_block_update_num_removes_in_update, tvb, offset+6, 2, false);
+  proto_tree_add_item(smrp_tree, hf_smrp_block_update_rfu1, tvb, offset+8, 16, false);
   *offset_ptr = offset+24;
 
   return 0;
@@ -227,10 +225,10 @@ dissect_block_contents_req(tvbuff_t *tvb, packet_info *pinfo _U_, proto_tree *sm
 
   if (tvb_captured_length_remaining(tvb, offset) < 16) return -1;
 
-  proto_tree_add_item(smrp_tree, hf_smrp_block_contents_req_block_id, tvb, offset, 4, FALSE);
-  proto_tree_add_item(smrp_tree, hf_smrp_block_contents_req_rfu0, tvb, offset+4, 4, FALSE);
-  proto_tree_add_item(smrp_tree, hf_smrp_block_contents_req_rfu1, tvb, offset+8, 4, FALSE);
-  proto_tree_add_item(smrp_tree, hf_smrp_block_contents_req_rfu2, tvb, offset+12, 4, FALSE);
+  proto_tree_add_item(smrp_tree, hf_smrp_block_contents_req_block_id, tvb, offset, 4, false);
+  proto_tree_add_item(smrp_tree, hf_smrp_block_contents_req_rfu0, tvb, offset+4, 4, false);
+  proto_tree_add_item(smrp_tree, hf_smrp_block_contents_req_rfu1, tvb, offset+8, 4, false);
+  proto_tree_add_item(smrp_tree, hf_smrp_block_contents_req_rfu2, tvb, offset+12, 4, false);
   *offset_ptr = offset+16;
   return 0;
 }
@@ -248,8 +246,8 @@ dissect_smrp_parms(tvbuff_t *tvb, packet_info *pinfo _U_, proto_tree *smrp_tree,
      // Check whether we can extract the tag and length
      if (tvb_captured_length_remaining(tvb, offset) < 2) return numParms;
 
-     parm = tvb_get_guint8(tvb, offset);
-     parm_len = tvb_get_guint8(tvb, offset+1);
+     parm = tvb_get_uint8(tvb, offset);
+     parm_len = tvb_get_uint8(tvb, offset+1);
      // Check for 
      if (parm_len == 0) {
         if (tvb_captured_length_remaining(tvb, offset) < 6) return numParms;
@@ -257,7 +255,7 @@ dissect_smrp_parms(tvbuff_t *tvb, packet_info *pinfo _U_, proto_tree *smrp_tree,
         parm_len -= 6;
 		if (parm_len <= 0) {
 			// invalid length
-			proto_tree_add_item(smrp_tree, hf_smrp_parm_bad_format, tvb, offset, -1, FALSE);
+			proto_tree_add_item(smrp_tree, hf_smrp_parm_bad_format, tvb, offset, -1, false);
 			return numParms;
 		}
         offset += 6;
@@ -268,59 +266,59 @@ dissect_smrp_parms(tvbuff_t *tvb, packet_info *pinfo _U_, proto_tree *smrp_tree,
 
      // Make sure there is actually enough data
      if (tvb_captured_length_remaining(tvb, offset) < parm_len) {
-         proto_tree_add_item(smrp_tree, hf_smrp_parm_bad_format, tvb, offset, -1, FALSE);
+         proto_tree_add_item(smrp_tree, hf_smrp_parm_bad_format, tvb, offset, -1, false);
          return numParms;
      }
 
      switch(parm)
      {
      case SMRP_ROUTER_NAME_PARM:
-         proto_tree_add_item(smrp_tree, hf_smrp_parm_router_name, tvb, offset, parm_len, FALSE);
+         proto_tree_add_item(smrp_tree, hf_smrp_parm_router_name, tvb, offset, parm_len, false);
          break;
 
      case SMRP_VPN_NAME_PARM:
-         proto_tree_add_item(smrp_tree, hf_smrp_parm_vpn_name, tvb, offset, parm_len, FALSE);
+         proto_tree_add_item(smrp_tree, hf_smrp_parm_vpn_name, tvb, offset, parm_len, false);
          break;
 
      case SMRP_BLOCK_INFO_PARM:
          // Min size of the Block Info structure is 24 bytes
          if (parm_len < 24) {
-            proto_tree_add_item(smrp_tree, hf_smrp_parm_bad_format, tvb, offset, -1, FALSE);
+            proto_tree_add_item(smrp_tree, hf_smrp_parm_bad_format, tvb, offset, -1, false);
             break;
          }
-         proto_tree_add_item(smrp_tree, hf_smrp_parm_block_info, tvb, offset, parm_len, FALSE);
-         proto_tree_add_item(smrp_tree, hf_smrp_parm_block_info_block_id, tvb, offset, 4, FALSE);
-         proto_tree_add_item(smrp_tree, hf_smrp_parm_block_info_seq_num, tvb, offset+4, 4, FALSE);
-         proto_tree_add_item(smrp_tree, hf_smrp_parm_block_info_block_key, tvb, offset+8, 8, FALSE);
-         proto_tree_add_item(smrp_tree, hf_smrp_parm_block_info_block_cs, tvb, offset+16, 4, FALSE);
-         proto_tree_add_item(smrp_tree, hf_smrp_parm_block_info_flags_cs, tvb, offset+20, 2, FALSE);
-         proto_tree_add_item(smrp_tree, hf_smrp_parm_block_info_flags_rfu0, tvb, offset+20, 2, FALSE);
-         proto_tree_add_item(smrp_tree, hf_smrp_parm_block_info_flags_p, tvb, offset+20, 2, FALSE);
-         proto_tree_add_item(smrp_tree, hf_smrp_parm_block_info_flags_rfu1, tvb, offset+20, 2, FALSE);
-         proto_tree_add_item(smrp_tree, hf_smrp_parm_block_info_flags_u, tvb, offset+20, 2, FALSE);
-         proto_tree_add_item(smrp_tree, hf_smrp_parm_block_info_num_subs, tvb, offset+22, 2, FALSE);
+         proto_tree_add_item(smrp_tree, hf_smrp_parm_block_info, tvb, offset, parm_len, false);
+         proto_tree_add_item(smrp_tree, hf_smrp_parm_block_info_block_id, tvb, offset, 4, false);
+         proto_tree_add_item(smrp_tree, hf_smrp_parm_block_info_seq_num, tvb, offset+4, 4, false);
+         proto_tree_add_item(smrp_tree, hf_smrp_parm_block_info_block_key, tvb, offset+8, 8, false);
+         proto_tree_add_item(smrp_tree, hf_smrp_parm_block_info_block_cs, tvb, offset+16, 4, false);
+         proto_tree_add_item(smrp_tree, hf_smrp_parm_block_info_flags_cs, tvb, offset+20, 2, false);
+         proto_tree_add_item(smrp_tree, hf_smrp_parm_block_info_flags_rfu0, tvb, offset+20, 2, false);
+         proto_tree_add_item(smrp_tree, hf_smrp_parm_block_info_flags_p, tvb, offset+20, 2, false);
+         proto_tree_add_item(smrp_tree, hf_smrp_parm_block_info_flags_rfu1, tvb, offset+20, 2, false);
+         proto_tree_add_item(smrp_tree, hf_smrp_parm_block_info_flags_u, tvb, offset+20, 2, false);
+         proto_tree_add_item(smrp_tree, hf_smrp_parm_block_info_num_subs, tvb, offset+22, 2, false);
          break;
 
      case SMRP_SUBS_INFO_PARM:
          // Min size of the Subscription Info structure is 20 bytes
          if (parm_len < 20) {
-            proto_tree_add_item(smrp_tree, hf_smrp_parm_bad_format, tvb, offset, -1, FALSE);
+            proto_tree_add_item(smrp_tree, hf_smrp_parm_bad_format, tvb, offset, -1, false);
             break;
          }
-         proto_tree_add_item(smrp_tree, hf_smrp_parm_subs_info, tvb, offset, parm_len, FALSE);
-         proto_tree_add_item(smrp_tree, hf_smrp_parm_subs_info_flags_r, tvb, offset, 2, FALSE);
-         proto_tree_add_item(smrp_tree, hf_smrp_parm_subs_info_flags_da, tvb, offset, 2, FALSE);
-         proto_tree_add_item(smrp_tree, hf_smrp_parm_subs_info_flags_rfu, tvb, offset, 2, FALSE);
-         proto_tree_add_item(smrp_tree, hf_smrp_parm_subs_info_subs_index, tvb, offset+2, 2, FALSE);
-         proto_tree_add_item(smrp_tree, hf_smrp_parm_subs_info_dto_weight, tvb, offset+4, 4, FALSE);
-         proto_tree_add_item(smrp_tree, hf_smrp_parm_subs_info_rfu, tvb, offset+8, 8, FALSE);
-         proto_tree_add_item(smrp_tree, hf_smrp_parm_subs_info_dto_pri, tvb, offset+16, 1, FALSE);
-         proto_tree_add_item(smrp_tree, hf_smrp_parm_subs_info_topic_size, tvb, offset+17, 1, FALSE);
-         proto_tree_add_item(smrp_tree, hf_smrp_parm_subs_info_topic_string, tvb, offset+18, parm_len-18, FALSE);
+         proto_tree_add_item(smrp_tree, hf_smrp_parm_subs_info, tvb, offset, parm_len, false);
+         proto_tree_add_item(smrp_tree, hf_smrp_parm_subs_info_flags_r, tvb, offset, 2, false);
+         proto_tree_add_item(smrp_tree, hf_smrp_parm_subs_info_flags_da, tvb, offset, 2, false);
+         proto_tree_add_item(smrp_tree, hf_smrp_parm_subs_info_flags_rfu, tvb, offset, 2, false);
+         proto_tree_add_item(smrp_tree, hf_smrp_parm_subs_info_subs_index, tvb, offset+2, 2, false);
+         proto_tree_add_item(smrp_tree, hf_smrp_parm_subs_info_dto_weight, tvb, offset+4, 4, false);
+         proto_tree_add_item(smrp_tree, hf_smrp_parm_subs_info_rfu, tvb, offset+8, 8, false);
+         proto_tree_add_item(smrp_tree, hf_smrp_parm_subs_info_dto_pri, tvb, offset+16, 1, false);
+         proto_tree_add_item(smrp_tree, hf_smrp_parm_subs_info_topic_size, tvb, offset+17, 1, false);
+         proto_tree_add_item(smrp_tree, hf_smrp_parm_subs_info_topic_string, tvb, offset+18, parm_len-18, false);
          break;
 
      default:
-         proto_tree_add_item(smrp_tree, hf_smrp_parm_unknown, tvb, offset, parm_len, FALSE);
+         proto_tree_add_item(smrp_tree, hf_smrp_parm_unknown, tvb, offset, parm_len, false);
          break;
      }
      offset += parm_len;
@@ -424,22 +422,22 @@ dissect_smrp(tvbuff_t *tvb, packet_info *pinfo, proto_tree *tree, void* data _U_
    offset to the end of the packet. */
 
 /* create display subtree for the protocol */
-        ti = proto_tree_add_item(tree, proto_smrp, tvb, 0, -1, FALSE);
+        ti = proto_tree_add_item(tree, proto_smrp, tvb, 0, -1, false);
 
         smrp_tree = proto_item_add_subtree(ti, ett_smrp);
 
         /* Dissect header fields */
-        proto_tree_add_item(smrp_tree, hf_smrp_ver, tvb, 0, 2, FALSE);
-        proto_tree_add_item(smrp_tree, hf_smrp_min_compat_ver, tvb, 2, 2, FALSE);
-        proto_tree_add_item(smrp_tree, hf_smrp_msg_len, tvb, 4, 4, FALSE);
-        proto_tree_add_item(smrp_tree, hf_smrp_rfu0, tvb, 8, 4, FALSE);
-        proto_tree_add_item(smrp_tree, hf_smrp_msg_type, tvb, 11, 1, FALSE);
-        proto_tree_add_item(smrp_tree, hf_smrp_router_name_hash, tvb, 12, 8, FALSE);
-        proto_tree_add_item(smrp_tree, hf_smrp_rfu1, tvb, 20, 16, FALSE);
+        proto_tree_add_item(smrp_tree, hf_smrp_ver, tvb, 0, 2, false);
+        proto_tree_add_item(smrp_tree, hf_smrp_min_compat_ver, tvb, 2, 2, false);
+        proto_tree_add_item(smrp_tree, hf_smrp_msg_len, tvb, 4, 4, false);
+        proto_tree_add_item(smrp_tree, hf_smrp_rfu0, tvb, 8, 4, false);
+        proto_tree_add_item(smrp_tree, hf_smrp_msg_type, tvb, 11, 1, false);
+        proto_tree_add_item(smrp_tree, hf_smrp_router_name_hash, tvb, 12, 8, false);
+        proto_tree_add_item(smrp_tree, hf_smrp_rfu1, tvb, 20, 16, false);
 
         /* Dissect contents */
         //msg_len = tvb_get_ntohl(tvb, 4); Commented out on July 24, 2019, since it is not being used. Seemed useful though, so I didn't delete it.
-        msg_type = tvb_get_guint8(tvb, 11) & 0x0f;
+        msg_type = tvb_get_uint8(tvb, 11) & 0x0f;
         offset = SMRP_MSG_HEADER_LEN;
 
         switch(msg_type)
@@ -800,7 +798,7 @@ proto_register_smrp(void)
     };
 
 /* Setup protocol subtree array */
-    static gint *ett[] = {
+    static int *ett[] = {
         &ett_smrp
     };
 
@@ -840,13 +838,13 @@ proto_register_smrp(void)
 void
 proto_reg_handoff_smrp(void)
 {
-    static gboolean inited = FALSE;
+    static bool inited = false;
         
     if (!inited) {
         //dissector_handle_t smrp_handle;
         //smrp_handle = create_dissector_handle(dissect_smrp, proto_smrp);        
         (void)create_dissector_handle(dissect_smrp, proto_smrp);
-	inited = TRUE;
+	inited = true;
     }
         
         /* 

--- a/src/smf/packet-subctrl.c
+++ b/src/smf/packet-subctrl.c
@@ -29,8 +29,6 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include <glib.h>
-
 #include <epan/packet.h>
 #include <epan/prefs.h>
 
@@ -71,11 +69,11 @@ static int hf_subctrl_csmp_vrid_param = -1;
 
 #if 0
 /* Global sample preference ("controls" display of numbers) */
-static gboolean gPREF_HEX = FALSE;
+static bool gPREF_HEX = false;
 #endif
 
 /* Initialize the subtree pointers */
-static gint ett_subctrl = -1;
+static int ett_subctrl = -1;
 
 #define SUBCTRL_UDP_PORT_PARAM 0x1
 #define SUBCTRL_UDP_MCAST_PARAM 0x2
@@ -100,13 +98,13 @@ clientctrl_dissect_rtr_capabilities_param(
     	proto_tree *tree,
     	int offset,
     	int size,
-        gboolean extended);
+        bool extended);
 
 static void
 add_subctrl_param(
     tvbuff_t *tvb,
     proto_tree *tree,
-    guint8 param_type,
+    uint8_t param_type,
     int offset,
     int size)
 {
@@ -118,110 +116,110 @@ add_subctrl_param(
         case SUBCTRL_UDP_PORT_PARAM:
             proto_tree_add_item(tree,
                 hf_subctrl_udp_port_param,
-                tvb, offset, size, FALSE);
+                tvb, offset, size, false);
             break;
 
         case SUBCTRL_UDP_MCAST_PARAM:
             proto_tree_add_item(tree,
                 hf_subctrl_udp_mcast_param,
-                tvb, offset-2, size+2, FALSE);
+                tvb, offset-2, size+2, false);
             break;
 
         case SUBCTRL_SUBSCRIPTION_SUMMARY_PARAM:
             proto_tree_add_item(tree,
                 hf_subctrl_subscription_summary_num_param,
-                tvb, offset, 3, FALSE);
+                tvb, offset, 3, false);
             proto_tree_add_item(tree,
                 hf_subctrl_subscription_summary_isfilter_param,
-                tvb, offset+3, 1, FALSE);
+                tvb, offset+3, 1, false);
             proto_tree_add_item(tree,
                 hf_subctrl_subscription_summary_xpelen_param,
-                tvb, offset+4, 2, FALSE);
+                tvb, offset+4, 2, false);
             proto_tree_add_item(tree,
                 hf_subctrl_subscription_summary_lastxpe_param,
-                tvb, offset+6, size-6, FALSE);
+                tvb, offset+6, size-6, false);
             break;
 
         case SUBCTRL_XPE_SEGMENT_PARAM:
             proto_tree_add_item(tree,
                 hf_subctrl_xpe_segment_param,
-                tvb, offset, size, FALSE);
+                tvb, offset, size, false);
             break;
 
         case SUBCTRL_UDP_MCAST_ADDR_PARAM:
             proto_tree_add_item(tree,
                 hf_subctrl_udp_mcast_addr_param,
-                tvb, offset, 4, FALSE);
+                tvb, offset, 4, false);
             proto_tree_add_item(tree,
                 hf_subctrl_udp_mcast_port_param,
-                tvb, offset+4, 2, FALSE);
+                tvb, offset+4, 2, false);
             proto_tree_add_item(tree,
                 hf_subctrl_udp_mcast_subid_param,
-                tvb, offset+6, 2, FALSE);
+                tvb, offset+6, 2, false);
             break;
 
         case SUBCTRL_REFRESH_REQUIRED_PARAM:
             proto_tree_add_item(tree,
                 hf_subctrl_refresh_required_param,
-                tvb, offset-2, size+2, FALSE);
+                tvb, offset-2, size+2, false);
             break;
 
         case SUBCTRL_UDP_UNICAST_ADDR_PARAM:
             proto_tree_add_item(tree,
                 hf_subctrl_udp_unicast_addr_param,
-                tvb, offset, size, FALSE);
+                tvb, offset, size, false);
             break;
 
         case SUBCTRL_SUBSCRIPTION_SUMMARY_V2_PARAM:
             proto_tree_add_item(tree,
                 hf_subctrl_subscription_summary_v2_num_param,
-                tvb, offset, 3, FALSE);
+                tvb, offset, 3, false);
             proto_tree_add_item(tree,
                 hf_subctrl_subscription_summary_v2_isfilter_param,
-                tvb, offset+3, 1, FALSE);
+                tvb, offset+3, 1, false);
 			proto_tree_add_item(tree,
                 hf_subctrl_subscription_summary_v2_cid_param,
-                tvb, offset+4, 4, FALSE);
+                tvb, offset+4, 4, false);
             proto_tree_add_item(tree,
                 hf_subctrl_subscription_summary_v2_xpelen_param,
-                tvb, offset+8, 2, FALSE);
+                tvb, offset+8, 2, false);
             proto_tree_add_item(tree,
                 hf_subctrl_subscription_summary_v2_lastxpe_param,
-                tvb, offset+10, size-10, FALSE);
+                tvb, offset+10, size-10, false);
             break;
 
         case SUBCTRL_RTR_CAPABILITIES_PARAM:
-            clientctrl_dissect_rtr_capabilities_param(tvb, tree, offset, size, FALSE);
+            clientctrl_dissect_rtr_capabilities_param(tvb, tree, offset, size, false);
             break;
 
         case SUBCTRL_SOFTWARE_VERSION_PARAM:
             proto_tree_add_item(tree,
                 hf_subctrl_software_version_param,
-                tvb, offset, size, FALSE);
+                tvb, offset, size, false);
             break;
 
         case SUBCTRL_SOFTWARE_DATE_PARAM:
             proto_tree_add_item(tree,
                 hf_subctrl_software_date_param,
-                tvb, offset, size, FALSE);
+                tvb, offset, size, false);
             break;
 
         case SUBCTRL_PLATFORM_PARAM:
             proto_tree_add_item(tree,
                 hf_subctrl_platform_param,
-                tvb, offset, size, FALSE);
+                tvb, offset, size, false);
             break;
 
 		case SUBCTRL_CSMP_VRID_PARAM:
             proto_tree_add_item(tree,
                 hf_subctrl_csmp_vrid_param,
-                tvb, offset, size, FALSE);
+                tvb, offset, size, false);
             break;
 
         default:
             proto_tree_add_item(tree,
                 hf_subctrl_unknown_param,
-                tvb, offset-2, size+2, FALSE);
+                tvb, offset-2, size+2, false);
             break;
 
     }
@@ -235,18 +233,18 @@ dissect_subctrl_param(
     proto_tree *tree)
 {
     int param_len;
-    guint8 param_type;
+    uint8_t param_type;
 
     /* Is it a pad byte? */
-    if (tvb_get_guint8(tvb, offset) == 0)
+    if (tvb_get_uint8(tvb, offset) == 0)
     {
         proto_tree_add_item(tree,
-            hf_subctrl_pad_byte, tvb, offset, 1, FALSE);
+            hf_subctrl_pad_byte, tvb, offset, 1, false);
         return 1;
     }
 
-    param_type = tvb_get_guint8(tvb, offset) & 0x1f;
-    param_len  = tvb_get_guint8(tvb, offset+1);
+    param_type = tvb_get_uint8(tvb, offset) & 0x1f;
+    param_len  = tvb_get_uint8(tvb, offset+1);
 
     add_subctrl_param(tvb, tree, param_type, offset, param_len);
 
@@ -379,15 +377,15 @@ dissect_subctrl(
    offset to the end of the packet. */
 
 /* create display subtree for the protocol */
-		ti = proto_tree_add_item(tree, proto_subctrl, tvb, 0, -1, FALSE);
+		ti = proto_tree_add_item(tree, proto_subctrl, tvb, 0, -1, false);
 
 		subctrl_tree = proto_item_add_subtree(ti, ett_subctrl);
 
         /* Dissect header fields */
 		proto_tree_add_item(subctrl_tree,
-		    hf_subctrl_version, tvb, 0, 1, FALSE);
+		    hf_subctrl_version, tvb, 0, 1, false);
         proto_tree_add_item(subctrl_tree,
-            hf_subctrl_msg_len, tvb, 1, 2, FALSE);
+            hf_subctrl_msg_len, tvb, 1, 2, false);
 
         /* Dissect parameters */
         header_len = tvb_get_ntohs(tvb, 1) & 0xfff;
@@ -549,7 +547,7 @@ proto_register_subctrl(void)
 	};
 
 /* Setup protocol subtree array */
-	static gint *ett[] = {
+	static int *ett[] = {
 		&ett_subctrl
 	};
 
@@ -588,7 +586,7 @@ proto_register_subctrl(void)
 void
 proto_reg_handoff_subctrl(void)
 {
-	static gboolean inited = FALSE;
+	static bool inited = false;
         
 	if (!inited) {
 
@@ -597,7 +595,7 @@ proto_reg_handoff_subctrl(void)
 	    (void)create_dissector_handle(dissect_subctrl, proto_subctrl);
 	    //dissector_add("smf.encap_proto", 0x8, subctrl_handle);
         
-	    inited = TRUE;
+	    inited = true;
 	}
         
         /* 

--- a/src/smf/packet-xmllink.c
+++ b/src/smf/packet-xmllink.c
@@ -29,8 +29,6 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include <glib.h>
-
 #include <epan/packet.h>
 #include <epan/prefs.h>
 
@@ -56,10 +54,10 @@ static int hf_xmllink_routing_control_address_param = -1;
 static int hf_xmllink_routing_control_address_port_param = -1;
 
 /* Global sample preference ("controls" display of numbers) */
-//static gboolean gPREF_HEX = FALSE;
+//static bool gPREF_HEX = false;
 
 /* Initialize the subtree pointers */
-static gint ett_xmllink = -1;
+static int ett_xmllink = -1;
 
 /* Conn priority to string */
 static const value_string connprionames[] = {
@@ -91,7 +89,7 @@ static void
 add_xmllink_param(
     tvbuff_t *tvb,
     proto_tree *tree,
-    guint8 param_type,
+    uint8_t param_type,
     int offset,
     int size)
 {
@@ -103,47 +101,47 @@ add_xmllink_param(
         case XMLLINK_CONN_PRIORITY_PARAM:
             proto_tree_add_item(tree,
                 hf_xmllink_conn_priority_param,
-                tvb, offset, size, FALSE);
+                tvb, offset, size, false);
             break;
 
         case XMLLINK_TCP_LISTENING_PORT_PARAM:
             proto_tree_add_item(tree,
                 hf_xmllink_tcp_listening_port_param,
-                tvb, offset, size, FALSE);
+                tvb, offset, size, false);
             break;
 
         case XMLLINK_UDP_LISTENING_PORT_PARAM:
             proto_tree_add_item(tree,
                 hf_xmllink_udp_listening_port_param,
-                tvb, offset, size, FALSE);
+                tvb, offset, size, false);
             break;
 
         case XMLLINK_OPERATING_MODE_PARAM:
             proto_tree_add_item(tree,
                 hf_xmllink_operating_mode_param,
-                tvb, offset, size, FALSE);
+                tvb, offset, size, false);
             break;
 
         case XMLLINK_HOSTNAME_PARAM:
             proto_tree_add_item(tree,
                 hf_xmllink_hostname_param,
-                tvb, offset, size, FALSE);
+                tvb, offset, size, false);
             break;
 
         case XMLLINK_ROUTING_CONTROL_ADDRESS_PARAM:
             // Display the address and port values separately
             proto_tree_add_item(tree,
                 hf_xmllink_routing_control_address_param,
-                tvb, offset, size-2, FALSE);
+                tvb, offset, size-2, false);
             proto_tree_add_item(tree,
                 hf_xmllink_routing_control_address_port_param,
-                tvb, offset+4, 2, FALSE);
+                tvb, offset+4, 2, false);
             break;
 
         default:
             proto_tree_add_item(tree,
                 hf_xmllink_unknown_param,
-                tvb, offset-2, size+2, FALSE);
+                tvb, offset-2, size+2, false);
             break;
     }
 }
@@ -156,18 +154,18 @@ dissect_xmllink_param(
     proto_tree *tree)
 {
     int param_len;
-    guint8 param_type;
+    uint8_t param_type;
 
     /* Is it a pad byte? */
-    if (tvb_get_guint8(tvb, offset) == 0)
+    if (tvb_get_uint8(tvb, offset) == 0)
     {
         proto_tree_add_item(tree,
-            hf_xmllink_pad_byte, tvb, offset, 1, FALSE);
+            hf_xmllink_pad_byte, tvb, offset, 1, false);
         return 1;
     }
 
-    param_type = tvb_get_guint8(tvb, offset) & 0x1f;
-    param_len  = tvb_get_guint8(tvb, offset+1);
+    param_type = tvb_get_uint8(tvb, offset) & 0x1f;
+    param_len  = tvb_get_uint8(tvb, offset+1);
 
     add_xmllink_param(tvb, tree, param_type, offset, param_len);
 
@@ -297,15 +295,15 @@ dissect_xmllink(tvbuff_t *tvb, packet_info *pinfo, proto_tree *tree, void* data 
    offset to the end of the packet. */
 
 /* create display subtree for the protocol */
-		ti = proto_tree_add_item(tree, proto_xmllink, tvb, 0, -1, FALSE);
+		ti = proto_tree_add_item(tree, proto_xmllink, tvb, 0, -1, false);
 
 		xmllink_tree = proto_item_add_subtree(ti, ett_xmllink);
 
         /* Dissect header fields */
 		proto_tree_add_item(xmllink_tree,
-		    hf_xmllink_version, tvb, 0, 1, FALSE);
+		    hf_xmllink_version, tvb, 0, 1, false);
         proto_tree_add_item(xmllink_tree,
-            hf_xmllink_msg_len, tvb, 1, 2, FALSE);
+            hf_xmllink_msg_len, tvb, 1, 2, false);
 
         /* Dissect parameters */
         header_len = tvb_get_ntohs(tvb, 1) & 0xfff;
@@ -388,7 +386,7 @@ proto_register_xmllink(void)
 	};
 
 /* Setup protocol subtree array */
-	static gint *ett[] = {
+	static int *ett[] = {
 		&ett_xmllink
 	};
 
@@ -427,7 +425,7 @@ proto_register_xmllink(void)
 void
 proto_reg_handoff_xmllink(void)
 {
-	static gboolean inited = FALSE;
+	static bool inited = false;
         
 	if (!inited) {
 
@@ -436,7 +434,7 @@ proto_reg_handoff_xmllink(void)
 	    (void)create_dissector_handle(dissect_xmllink, proto_xmllink);
 	    //dissector_add("smf.encap_proto", 0x8, xmllink_handle);
         
-	    inited = TRUE;
+	    inited = true;
 	}
         
         /* 

--- a/src/smf/perftool-decoder.c
+++ b/src/smf/perftool-decoder.c
@@ -29,8 +29,6 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include <glib.h>
-
 #include <epan/packet.h>
 #include <epan/prefs.h>
 
@@ -43,7 +41,7 @@ add_tooldata_block(proto_tree *bm_tree, int headerFieldIndex, tvbuff_t *tvb, int
 	int pos;			/* position in payload */
 	char *buffer;       /* temp buffer to hold our decode string */
     char *pad_buf;		/* buffer to use for left-padding our decode string */
-	guint32 field_bitmap;
+	uint32_t field_bitmap;
 
     /* Generate a padding leader */
     pad_buf = (char*)malloc(2);
@@ -108,13 +106,13 @@ add_tooldata_block(proto_tree *bm_tree, int headerFieldIndex, tvbuff_t *tvb, int
 	}
 	if (field_bitmap & 0x40)
 	{
-		g_snprintf(buffer, 300, "%sRepublished Flag = TRUE",
+		g_snprintf(buffer, 300, "%sRepublished Flag = true",
                                pad_buf);
 		proto_tree_add_string(bm_tree, headerFieldIndex, tvb, start_offset + 7, 1, buffer);
 	}
 	else
 	{
-		g_snprintf(buffer, 300, "%sRepublished Flag = FALSE",
+		g_snprintf(buffer, 300, "%sRepublished Flag = false",
                                pad_buf);
 		proto_tree_add_string(bm_tree, headerFieldIndex, tvb, start_offset + 7, 1, buffer);
 	}

--- a/src/smf/sdt-decoder.h
+++ b/src/smf/sdt-decoder.h
@@ -31,7 +31,7 @@
 extern int ett_trace_span_message_creation_context;
 
 void
-add_sdt_block(proto_tree *bm_tree, packet_info* pinfo, int headerFieldIndex, tvbuff_t *tvb, int offset, int length, int indent, gboolean is_in_map);
+add_sdt_block(proto_tree *bm_tree, packet_info* pinfo, int headerFieldIndex, tvbuff_t *tvb, int offset, int length, int indent, bool is_in_map);
 
 void get_embedded_smf_info(tvbuff_t *tvb, int offset, int length, int *embedded_smf_info);
 

--- a/src/smf/smf-analysis.c
+++ b/src/smf/smf-analysis.c
@@ -86,16 +86,16 @@ typedef struct _smf_analysis_buf_t {
     // Collected info
     // It is not nessary to store this info.
     // It is here for convinence instead of parameter passing.
-    guint64 ad_msg_id_m;
+    uint64_t ad_msg_id_m;
     int isFlowIdKnown_m;
-    guint32 ad_flow_id_m;
+    uint32_t ad_flow_id_m;
     
     // Analysised info
-    guint32 numMsgInTransport_m; // This is the number of messages still in the transport window.
-    guint32 numUnackedMsg_m; // This is the number of messages unack by the application.
+    uint32_t numMsgInTransport_m; // This is the number of messages still in the transport window.
+    uint32_t numUnackedMsg_m; // This is the number of messages unack by the application.
     int isTransportWindownKnown_m;
-    guint32 transport_window_size_m; // Available transport window
-    guint32 transport_ack_frame_m;
+    uint32_t transport_window_size_m; // Available transport window
+    uint32_t transport_ack_frame_m;
 } smf_analysis_buf_t;
 
 // DOTO: Remove
@@ -105,14 +105,14 @@ typedef struct _smf_analysis_buf_t {
 typedef struct _smf_analysis_assuredctrl_buf_t {
     // Collected info
     int isFlowIdKnown_m;
-    guint32 ad_flow_id_m;
+    uint32_t ad_flow_id_m;
 
     // Analysised info
-    guint32 numTransportMsg_m; // This is the number of transport messages acknowledged by this message.
-    guint32 numMsgInTransport_m; // This is the number of messages still in the transport window. 
+    uint32_t numTransportMsg_m; // This is the number of transport messages acknowledged by this message.
+    uint32_t numMsgInTransport_m; // This is the number of messages still in the transport window. 
     wmem_list_t *transportAckList_m;
-    guint32 numAckedMsg_m;   // This is the number of messages App acked by this message.
-    guint32 numUnackedMsg_m; // This is the number of messages unack by the application.
+    uint32_t numAckedMsg_m;   // This is the number of messages App acked by this message.
+    uint32_t numUnackedMsg_m; // This is the number of messages unack by the application.
     nstime_t min_transdeltatime_m;
     nstime_t max_transdeltatime_m;
     wmem_list_t *appAckList_m;
@@ -145,11 +145,11 @@ static smf_analysis_buf_t* getSmfAnalysisProtoData(tvbuff_t* tvb, packet_info* p
             wmem_file_scope(), 
             pinfo,
             proto_smf, 
-            (guint32)tvb_raw_offset(tvb));
+            (uint32_t)tvb_raw_offset(tvb));
     if (NULL == smf_analysis_buf_p) {
         smf_analysis_buf_p = wmem_new0(wmem_file_scope(), smf_analysis_buf_t);
         p_add_proto_data(wmem_file_scope(), pinfo, proto_smf,
-                (guint32)tvb_raw_offset(tvb), smf_analysis_buf_p);
+                (uint32_t)tvb_raw_offset(tvb), smf_analysis_buf_p);
         
     }
     return smf_analysis_buf_p;
@@ -163,7 +163,7 @@ static smf_analysis_assuredctrl_buf_t* getAssuredCtrlAnalysisProtoData(tvbuff_t*
             wmem_file_scope(), 
             pinfo,
             proto_assuredctrl, 
-            (guint32)tvb_raw_offset(tvb));
+            (uint32_t)tvb_raw_offset(tvb));
     if (NULL == smf_analysis_assuredctrl_buf_p) {
         smf_analysis_assuredctrl_buf_p = wmem_new0(wmem_file_scope(), smf_analysis_assuredctrl_buf_t);
         smf_analysis_assuredctrl_buf_p->transportAckList_m = wmem_list_new(wmem_file_scope());
@@ -172,7 +172,7 @@ static smf_analysis_assuredctrl_buf_t* getAssuredCtrlAnalysisProtoData(tvbuff_t*
         nstime_set_unset(&smf_analysis_assuredctrl_buf_p->min_transdeltatime_m);
         nstime_set_unset(&smf_analysis_assuredctrl_buf_p->max_transdeltatime_m);
         p_add_proto_data(wmem_file_scope(), pinfo, proto_assuredctrl,
-                (guint32)tvb_raw_offset(tvb), smf_analysis_assuredctrl_buf_p);
+                (uint32_t)tvb_raw_offset(tvb), smf_analysis_assuredctrl_buf_p);
     }
     return smf_analysis_assuredctrl_buf_p;
 }
@@ -182,12 +182,12 @@ static smf_analysis_assuredctrl_buf_t* getAssuredCtrlAnalysisProtoData(tvbuff_t*
 //*************************************************
 // structure about each message
 typedef struct _smf_ad_msg_t {
-    guint64 msg_id_m;
-    guint32 frame_m;
+    uint64_t msg_id_m;
+    uint32_t frame_m;
     nstime_t time_m;
 } smf_ad_msg_t;
 
-static smf_ad_msg_t* create_msg(guint64 msg_id_m) {
+static smf_ad_msg_t* create_msg(uint64_t msg_id_m) {
     smf_ad_msg_t *msg_p = wmem_new0(wmem_file_scope(), smf_ad_msg_t);
     msg_p->msg_id_m = msg_id_m;
     return msg_p;
@@ -200,19 +200,19 @@ static void putMsgIntoList(wmem_list_t *appAckList_p, smf_ad_msg_t *ad_msg) {
 // Transaction Ack list structure
 typedef struct _trans_ack_msg_t {
     // Collected info
-    guint32 ad_flow_id_m;
-    guint32 messageCount_m;
+    uint32_t ad_flow_id_m;
+    uint32_t messageCount_m;
 
     // Analysised info
-    guint32 numTransportMsg_m; // This is the number of transport messages acknowledged by this message.
-    guint32 numMsgInTransport_m; // This is the number of messages still in the transport window. 
+    uint32_t numTransportMsg_m; // This is the number of transport messages acknowledged by this message.
+    uint32_t numMsgInTransport_m; // This is the number of messages still in the transport window. 
     wmem_list_t *transportAckList_m;
-    guint32 numAckedMsg_m;   // This is the number of messages App acked by this message.
-    guint32 numUnackedMsg_m; // This is the number of messages unack by the application.
+    uint32_t numAckedMsg_m;   // This is the number of messages App acked by this message.
+    uint32_t numUnackedMsg_m; // This is the number of messages unack by the application.
     wmem_list_t *appAckList_m;
 } trans_ack_msg_t;
 
-static trans_ack_msg_t* create_trans_ack_msg(guint32 flow_id) {
+static trans_ack_msg_t* create_trans_ack_msg(uint32_t flow_id) {
     trans_ack_msg_t *msg_p = wmem_new0(wmem_file_scope(), trans_ack_msg_t);
     msg_p->ad_flow_id_m = flow_id;
     msg_p->transportAckList_m = wmem_list_new(wmem_file_scope());
@@ -225,21 +225,21 @@ static void putTransIntoList(wmem_list_t *transList_p, trans_ack_msg_t *trans_ac
 }
 
 typedef struct _smf_flow_t {
-    guint32 flow_id_m;
+    uint32_t flow_id_m;
     int isFlowTypeKnown_m;
     int flowType_m;
     int isCombinedTransportAppAck_m; // Transport and App Ack are combined?
-    gint32 maxDeliveredUnackedMsgsPerFlow_m;
+    int32_t maxDeliveredUnackedMsgsPerFlow_m;
     int isTransportWindownKnown_m;
-    guint32 transport_window_size_m; // Transport window available
-    guint32 transport_ack_frame_m;
+    uint32_t transport_window_size_m; // Transport window available
+    uint32_t transport_ack_frame_m;
     int numMsgInTransport_m; // Number of messages in Transport
     int numMsgUnacked_m;
     wmem_list_t *msgsInTransport_m;
     wmem_list_t *msgsUnacked_m;
 } smf_flow_t;
 
-static void init_smf_flow(smf_flow_t *flow_p, guint32 flow_id) {
+static void init_smf_flow(smf_flow_t *flow_p, uint32_t flow_id) {
     flow_p->flow_id_m = flow_id;
     flow_p->maxDeliveredUnackedMsgsPerFlow_m = -1;
     flow_p->msgsInTransport_m = wmem_list_new(wmem_file_scope());
@@ -267,7 +267,7 @@ static void init_smf_stream(smf_stream_t *stream_p) {
     stream_p->flows = wmem_tree_new(wmem_file_scope());
 }
 
-static smf_flow_t* find_or_create_smf_flow(smf_stream_t *stream_p, guint32 flow_id) {
+static smf_flow_t* find_or_create_smf_flow(smf_stream_t *stream_p, uint32_t flow_id) {
     smf_flow_t *flow_p = (smf_flow_t *)wmem_tree_lookup32(stream_p->flows, flow_id);
     if (flow_p != NULL) {
         if (flow_id == flow_p->flow_id_m) {
@@ -305,19 +305,19 @@ void init_smf_conv(smf_conv_t *smf_conv_p) {
 }
 
 // Save the parameters that we are interested in
-void smf_analysis_param(tvbuff_t *tvb, packet_info *pinfo, guint8 param_type, int offset) {
+void smf_analysis_param(tvbuff_t *tvb, packet_info *pinfo, uint8_t param_type, int offset) {
     smf_analysis_buf_t *smf_analysis_buf_p = getSmfAnalysisProtoData(tvb, pinfo);
     switch (param_type) 
     {
         case 0x11: // Assured Delivery Message Id
         {            
-            smf_analysis_buf_p->ad_msg_id_m = tvb_get_guint64(tvb, offset, FALSE);
+            smf_analysis_buf_p->ad_msg_id_m = tvb_get_uint64(tvb, offset, false);
             break;
         }
         case 0x17: // Assured Delivery Flow Id
         {
             smf_analysis_buf_p->isFlowIdKnown_m = 1;
-            smf_analysis_buf_p->ad_flow_id_m = tvb_get_guint32(tvb, offset, FALSE);
+            smf_analysis_buf_p->ad_flow_id_m = tvb_get_uint32(tvb, offset, false);
             break;
         }
         default:
@@ -364,8 +364,8 @@ int smf_analysis(tvbuff_t* tvb, packet_info* pinfo, proto_tree* tree)
 {
     smf_stream_t *currentStream_p;
 
-    guint8 firstByte = tvb_get_guint8(tvb, 0);
-    gboolean adflag = (firstByte & 0x10); // AD flag
+    uint8_t firstByte = tvb_get_uint8(tvb, 0);
+    bool adflag = (firstByte & 0x10); // AD flag
     currentStream_p = smf_analysis_get_stream(pinfo, 1 /* forward */);
 
     smf_analysis_buf_t *smf_analysis_buf_p = getSmfAnalysisProtoData(tvb, pinfo);
@@ -443,7 +443,7 @@ int smf_analysis(tvbuff_t* tvb, packet_info* pinfo, proto_tree* tree)
         item = proto_tree_add_uint(flags_tree, hf_smf_analysis_msg_unacked,
                                 tvb, 0, 0, smf_analysis_buf_p->numUnackedMsg_m);
         if (smf_flow_p->maxDeliveredUnackedMsgsPerFlow_m != -1) {
-            if (smf_analysis_buf_p->numUnackedMsg_m == (guint32)smf_flow_p->maxDeliveredUnackedMsgsPerFlow_m) {
+            if (smf_analysis_buf_p->numUnackedMsg_m == (uint32_t)smf_flow_p->maxDeliveredUnackedMsgsPerFlow_m) {
                 expert_add_info(pinfo, item, &ei_smf_expert_max_delivered_unacked_msgs);
                 col_append_fstr(pinfo->cinfo, COL_INFO, "[MaxDeliveredUnackedMsgs reached]  ");            
             }
@@ -454,25 +454,25 @@ int smf_analysis(tvbuff_t* tvb, packet_info* pinfo, proto_tree* tree)
     return 0;
 }
 
-void smf_analysis_assuredctrl_param(tvbuff_t *tvb, packet_info* pinfo, guint8 param_type, int offset, int size) {
+void smf_analysis_assuredctrl_param(tvbuff_t *tvb, packet_info* pinfo, uint8_t param_type, int offset, int size) {
     // The flow information is stored in the reverse direction relative to the ack message
     smf_stream_t *forwardStream_p = smf_analysis_get_stream(pinfo, 1 /* forward stream */);
     smf_stream_t *reverseStream_p = smf_analysis_get_stream(pinfo, -1 /* reverse stream */);
     smf_analysis_assuredctrl_buf_t *smf_analysis_assuredctrl_buf_p = getAssuredCtrlAnalysisProtoData(tvb, pinfo);
 
     if (!PINFO_FD_VISITED(pinfo)) {
-        int version = (tvb_get_guint8(tvb, 0) & 0x3f);
+        int version = (tvb_get_uint8(tvb, 0) & 0x3f);
         int msg_type;
         if (version < 3) { 
-            msg_type = (tvb_get_guint8(tvb, 1) & 0xf0) >> 4; 
+            msg_type = (tvb_get_uint8(tvb, 1) & 0xf0) >> 4; 
         } else { 
-            msg_type = tvb_get_guint8(tvb, 1); 
+            msg_type = tvb_get_uint8(tvb, 1); 
         }
         switch (param_type) {
             case 0x02:  { // ASSUREDCTRL_LAST_MSGID_ACKED_PARAM
                 // Determine how many messages are removed from transport
                 // Put this in a transport list in smf_analysis_buf_p
-                guint64 last_msgid_acked = tvb_get_guint64(tvb, offset, FALSE);
+                uint64_t last_msgid_acked = tvb_get_uint64(tvb, offset, false);
                 smf_flow_t *smf_flow_p;
                 wmem_list_frame_t *frame_p;
                 nstime_t min_transdeltatime = {INT_MAX-1, 0};
@@ -535,15 +535,15 @@ void smf_analysis_assuredctrl_param(tvbuff_t *tvb, packet_info* pinfo, guint8 pa
                 }
                 smf_flow_p = find_or_create_smf_flow(reverseStream_p, smf_analysis_assuredctrl_buf_p->ad_flow_id_m);
                 smf_flow_p->isTransportWindownKnown_m = 1;
-                smf_flow_p->transport_window_size_m = tvb_get_guint8(tvb, offset);
+                smf_flow_p->transport_window_size_m = tvb_get_uint8(tvb, offset);
                 smf_flow_p->transport_ack_frame_m = pinfo->fd->num;
                 break;
             }
             case 0x05: { // ASSUREDCTRL_APPLICATION_ACK_PARAM
                 // Determine how many messages are acked and remove from unacked list
                 // Put this in an ack list in smf_analysis_buf_p
-                guint64 ack_min_id = tvb_get_guint64(tvb, offset, FALSE);
-                guint64 ack_max_id = tvb_get_guint64(tvb, offset+8, FALSE);
+                uint64_t ack_min_id = tvb_get_uint64(tvb, offset, false);
+                uint64_t ack_max_id = tvb_get_uint64(tvb, offset+8, false);
                 smf_flow_t *smf_flow_p;
                 wmem_list_frame_t *frame_p;
                 if (0 == smf_analysis_assuredctrl_buf_p->isFlowIdKnown_m) {
@@ -578,7 +578,7 @@ void smf_analysis_assuredctrl_param(tvbuff_t *tvb, packet_info* pinfo, guint8 pa
             case 0x06: { // ASSUREDCTRL_FLOWID_PARAM
                 smf_flow_t *smf_flow_p;
                 smf_analysis_assuredctrl_buf_p->isFlowIdKnown_m = 1;
-                smf_analysis_assuredctrl_buf_p->ad_flow_id_m = tvb_get_guint32(tvb, offset, FALSE);
+                smf_analysis_assuredctrl_buf_p->ad_flow_id_m = tvb_get_uint32(tvb, offset, false);
 
                 // Determine if this is a bind (to an endpoint). If it is NOT a bind, then no applicaiton ack is needed.
                 switch (msg_type) { 
@@ -612,16 +612,16 @@ void smf_analysis_assuredctrl_param(tvbuff_t *tvb, packet_info* pinfo, guint8 pa
                 }
                 smf_flow_p = find_or_create_smf_flow(reverseStream_p, smf_analysis_assuredctrl_buf_p->ad_flow_id_m);
                 smf_flow_p->isTransportWindownKnown_m = 1;
-                smf_flow_p->transport_window_size_m = tvb_get_guint32(tvb, offset, FALSE);
+                smf_flow_p->transport_window_size_m = tvb_get_uint32(tvb, offset, false);
                 smf_flow_p->transport_ack_frame_m = pinfo->fd->num;
                 break;
             }
             case 0x1c: // ASSUREDCTRL_TRANSACTIONFLOWDESCRIPTORPUBNOTIFY_PARAM
             {
                 int local_offset = offset;
-                guint32 flowid = 0;
-                guint32 messageCount = 0;
-                guint64 lastMsgId = 0;
+                uint32_t flowid = 0;
+                uint32_t messageCount = 0;
+                uint64_t lastMsgId = 0;
                 while( local_offset < offset+size )
                 {
                     flowid = tvb_get_ntohl(tvb, local_offset); // 32 bit flowid
@@ -665,12 +665,12 @@ void smf_analysis_assuredctrl_param(tvbuff_t *tvb, packet_info* pinfo, guint8 pa
             case 0x1e: //ASSUREDCTRL_TRANSACTIONFLOWDESCRIPTORSUBACK_PARAM
             {
                 int local_offset = offset;
-                guint32 flowid = 0;
-                guint64 min = 0;
-                guint64 max = 0;
-                guint32 msgCount = 0;
-                guint64 lastMsgIdRecved = 0;
-                guint32 windowSz = 0;
+                uint32_t flowid = 0;
+                uint64_t min = 0;
+                uint64_t max = 0;
+                uint32_t msgCount = 0;
+                uint64_t lastMsgIdRecved = 0;
+                uint32_t windowSz = 0;
                 while( local_offset < offset+size )
                 {
                     flowid = tvb_get_ntohl(tvb, local_offset); // 32 bit flowid
@@ -725,7 +725,7 @@ void smf_analysis_assuredctrl_param(tvbuff_t *tvb, packet_info* pinfo, guint8 pa
                     break;
                 }
                 smf_flow_p = find_or_create_smf_flow(reverseStream_p, smf_analysis_assuredctrl_buf_p->ad_flow_id_m);
-                smf_flow_p->maxDeliveredUnackedMsgsPerFlow_m = tvb_get_gint32(tvb, offset, FALSE);
+                smf_flow_p->maxDeliveredUnackedMsgsPerFlow_m = tvb_get_int32(tvb, offset, false);
                 break;
             }
             default:
@@ -736,7 +736,7 @@ void smf_analysis_assuredctrl_param(tvbuff_t *tvb, packet_info* pinfo, guint8 pa
 
 void smf_analysis_assuredctrl(tvbuff_t *tvb, packet_info* pinfo, proto_tree* tree) {
     smf_analysis_assuredctrl_buf_t *smf_analysis_assuredctrl_buf_p = (smf_analysis_assuredctrl_buf_t *)p_get_proto_data(wmem_file_scope(), pinfo,
-            getAssuredCtrlProto(), (guint32)tvb_raw_offset(tvb));
+            getAssuredCtrlProto(), (uint32_t)tvb_raw_offset(tvb));
     if (smf_analysis_assuredctrl_buf_p->numTransportMsg_m != 0 || smf_analysis_assuredctrl_buf_p->numAckedMsg_m != 0) {
         proto_item *item = proto_tree_add_item(tree, hf_assuredctrl_smf_analysis, tvb, 0, 0, ENC_NA);
         proto_item_set_generated(item);

--- a/src/smf/smf-analysis.h
+++ b/src/smf/smf-analysis.h
@@ -160,9 +160,9 @@ extern int ett_assuredctrl_analysis;
 
 int smf_analysis(tvbuff_t* tvb, packet_info* pinfo, proto_tree* tree);
 
-void smf_analysis_param(tvbuff_t *tvb, packet_info* pinfo, guint8 param_type, int offset);
+void smf_analysis_param(tvbuff_t *tvb, packet_info* pinfo, uint8_t param_type, int offset);
 
-void smf_analysis_assuredctrl_param(tvbuff_t *tvb, packet_info* pinfo, guint8 param_type, int offset, int size);
+void smf_analysis_assuredctrl_param(tvbuff_t *tvb, packet_info* pinfo, uint8_t param_type, int offset, int size);
 
 void smf_analysis_assuredctrl(tvbuff_t *tvb, packet_info* pinfo, proto_tree* tree);
 


### PR DESCRIPTION
This fixes a few things so that the plugin compiles and runs on Wireshark 4.4. It mainly changes our use of GLib types to C99 types.

The API changes can be found here: https://www.wireshark.org/docs/relnotes/wireshark-4.4.0.html#_major_api_changes

Note that we do not implement `plugin_describe()`, but it compiles regardless. We may want to implement it eventually, if required (I'm not quite sure what it is for).