### PR TITLE
Fix typo in "Ack Sequence Number"

### DIFF
--- a/src/smf/packet-assuredctrl.c
+++ b/src/smf/packet-assuredctrl.c
@@ -3004,7 +3004,7 @@ proto_register_assuredctrl(void)
             "", HFILL }
         },
         { &hf_assuredctrl_ackSequenceNum_param,
-            { "Ack Seqeunce Number",           "assuredctrl.ackSequenceNum",
+            { "Ack Sequence Number",           "assuredctrl.ackSequenceNum",
             FT_UINT16, BASE_DEC, NULL, 0x0,          
             "", HFILL } 
         },


### PR DESCRIPTION
There is a typo in "Ack Sequence Number", this fixes it.