### PR TITLE
Decode binary metadata when there is enough length

### DIFF
--- a/src/smf/packet-smf.c
+++ b/src/smf/packet-smf.c
@@ -1990,7 +1990,7 @@ static int dissect_smf_common(tvbuff_t* tvb, packet_info* pinfo, proto_tree* tre
                 int metadata_start = payload_offset + param_info.binary_metadata_start;
                 int remaining_len = tvb_reported_length_remaining(tvb, metadata_start);
                 // Check to see still have data to dissect
-                if (remaining_len > param_info.binary_metadata_length) {
+                if (remaining_len >= param_info.binary_metadata_length) {
                     next_tvb = tvb_new_subset_length_caplen(tvb,
                         metadata_start,
                         -1,


### PR DESCRIPTION
Bug in the code. Should be greater-than-or-equal, instead of great-than.