### PR TITLE
Patch version

### DIFF
--- a/.github/workflows/build_plugin.yml
+++ b/.github/workflows/build_plugin.yml
@@ -18,6 +18,10 @@ on:
         description: "Patch version of the wireshark tag to use when building plugin"
         required: false
         default: ''
+      SMF_PLUGIN_PATCH_VERSION:
+        description: "PATCH for SMF plugin"
+        required: true
+        default: ''
 jobs:
   # Commenting out intel mac for regular builds as it is currently broken.
   #build_macos:
@@ -32,15 +36,20 @@ jobs:
       MAJOR_VERSION: ${{ inputs.MAJOR_VERSION || '4' }}
       MINOR_VERSION: ${{ inputs.MINOR_VERSION || '4' }}
       PATCH_VERSION: ${{ inputs.PATCH_VERSION || '0' }}
+      SMF_PLUGIN_PATCH_VERSION: ${{ inputs.SMF_PLUGIN_PATCH_VERSION || "dev" }}
   build_windows:
     uses: ./.github/workflows/windows.yml
     with:
       MAJOR_VERSION: ${{ inputs.MAJOR_VERSION || '4' }}
       MINOR_VERSION: ${{ inputs.MINOR_VERSION || '4' }}
       PATCH_VERSION: ${{ inputs.PATCH_VERSION || '0' }}
+      # this goes into FILEVERSION which appears when you hover over the DLL, but cannot 
+      # contain a string like "dev"
+      SMF_PLUGIN_PATCH_VERSION: ${{ inputs.SMF_PLUGIN_PATCH_VERSION || "0" }}
   build_linux:
     uses: ./.github/workflows/ubuntu.yml
     with:
       MAJOR_VERSION: ${{ inputs.MAJOR_VERSION || '4' }}
       MINOR_VERSION: ${{ inputs.MINOR_VERSION || '4' }}
       PATCH_VERSION: ${{ inputs.PATCH_VERSION || '0' }}
+      SMF_PLUGIN_PATCH_VERSION: ${{ inputs.SMF_PLUGIN_PATCH_VERSION || "dev" }}

--- a/.github/workflows/build_plugin.yml
+++ b/.github/workflows/build_plugin.yml
@@ -36,7 +36,7 @@ jobs:
       MAJOR_VERSION: ${{ inputs.MAJOR_VERSION || '4' }}
       MINOR_VERSION: ${{ inputs.MINOR_VERSION || '4' }}
       PATCH_VERSION: ${{ inputs.PATCH_VERSION || '0' }}
-      SMF_PLUGIN_PATCH_VERSION: ${{ inputs.SMF_PLUGIN_PATCH_VERSION || "dev" }}
+      SMF_PLUGIN_PATCH_VERSION: ${{ inputs.SMF_PLUGIN_PATCH_VERSION || 'dev' }}
   build_windows:
     uses: ./.github/workflows/windows.yml
     with:
@@ -45,11 +45,11 @@ jobs:
       PATCH_VERSION: ${{ inputs.PATCH_VERSION || '0' }}
       # this goes into FILEVERSION which appears when you hover over the DLL, but cannot 
       # contain a string like "dev"
-      SMF_PLUGIN_PATCH_VERSION: ${{ inputs.SMF_PLUGIN_PATCH_VERSION || "0" }}
+      SMF_PLUGIN_PATCH_VERSION: ${{ inputs.SMF_PLUGIN_PATCH_VERSION || '0' }}
   build_linux:
     uses: ./.github/workflows/ubuntu.yml
     with:
       MAJOR_VERSION: ${{ inputs.MAJOR_VERSION || '4' }}
       MINOR_VERSION: ${{ inputs.MINOR_VERSION || '4' }}
       PATCH_VERSION: ${{ inputs.PATCH_VERSION || '0' }}
-      SMF_PLUGIN_PATCH_VERSION: ${{ inputs.SMF_PLUGIN_PATCH_VERSION || "dev" }}
+      SMF_PLUGIN_PATCH_VERSION: ${{ inputs.SMF_PLUGIN_PATCH_VERSION || 'dev' }}

--- a/.github/workflows/build_plugin.yml
+++ b/.github/workflows/build_plugin.yml
@@ -20,6 +20,7 @@ on:
         default: ''
       SMF_PLUGIN_PATCH_VERSION:
         description: "PATCH for SMF plugin"
+        type: string
         required: true
         default: ''
 jobs:

--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -30,7 +30,7 @@ jobs:
       MAJOR_VERSION: ${{ inputs.MAJOR_VERSION || '4' }}
       MINOR_VERSION: ${{ inputs.MINOR_VERSION || '4' }}
       PATCH_VERSION: ${{ inputs.PATCH_VERSION || '0' }}
-      SMF_PLUGIN_PATCH_VERSION: ${{ inputs.SMF_PLUGIN_PATCH_VERSION || "0" }}
+      SMF_PLUGIN_PATCH_VERSION: ${{ inputs.SMF_PLUGIN_PATCH_VERSION || '0' }}
   
   build_windows:
     uses: SolaceLabs/wireshark-smf-plugin/.github/workflows/windows.yml@main
@@ -38,7 +38,7 @@ jobs:
       MAJOR_VERSION: ${{ inputs.MAJOR_VERSION || '4' }}
       MINOR_VERSION: ${{ inputs.MINOR_VERSION || '4' }}
       PATCH_VERSION: ${{ inputs.PATCH_VERSION || '0' }}
-      SMF_PLUGIN_PATCH_VERSION: ${{ inputs.SMF_PLUGIN_PATCH_VERSION || "0" }}
+      SMF_PLUGIN_PATCH_VERSION: ${{ inputs.SMF_PLUGIN_PATCH_VERSION || '0' }}
     
   build_macos:
     uses: SolaceLabs/wireshark-smf-plugin/.github/workflows/macos_arm64.yml@main
@@ -46,7 +46,7 @@ jobs:
       MAJOR_VERSION: ${{ inputs.MAJOR_VERSION || '4' }}
       MINOR_VERSION: ${{ inputs.MINOR_VERSION || '4' }}
       PATCH_VERSION: ${{ inputs.PATCH_VERSION || '0' }}
-      SMF_PLUGIN_PATCH_VERSION: ${{ inputs.SMF_PLUGIN_PATCH_VERSION || "0" }}
+      SMF_PLUGIN_PATCH_VERSION: ${{ inputs.SMF_PLUGIN_PATCH_VERSION || '0' }}
       
   create_release:
     runs-on: ubuntu-latest

--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -16,6 +16,7 @@ on:
           default: '5'
       SMF_PLUGIN_PATCH_VERSION:
         description: "PATCH for SMF plugin"
+        type: string
         required: true
         default: ''
 env:

--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -30,6 +30,7 @@ jobs:
       MAJOR_VERSION: ${{ inputs.MAJOR_VERSION || '4' }}
       MINOR_VERSION: ${{ inputs.MINOR_VERSION || '4' }}
       PATCH_VERSION: ${{ inputs.PATCH_VERSION || '0' }}
+      SMF_PLUGIN_PATCH_VERSION: ${{ inputs.SMF_PLUGIN_PATCH_VERSION || "0" }}
   
   build_windows:
     uses: SolaceLabs/wireshark-smf-plugin/.github/workflows/windows.yml@main
@@ -37,6 +38,7 @@ jobs:
       MAJOR_VERSION: ${{ inputs.MAJOR_VERSION || '4' }}
       MINOR_VERSION: ${{ inputs.MINOR_VERSION || '4' }}
       PATCH_VERSION: ${{ inputs.PATCH_VERSION || '0' }}
+      SMF_PLUGIN_PATCH_VERSION: ${{ inputs.SMF_PLUGIN_PATCH_VERSION || "0" }}
     
   build_macos:
     uses: SolaceLabs/wireshark-smf-plugin/.github/workflows/macos_arm64.yml@main
@@ -44,6 +46,7 @@ jobs:
       MAJOR_VERSION: ${{ inputs.MAJOR_VERSION || '4' }}
       MINOR_VERSION: ${{ inputs.MINOR_VERSION || '4' }}
       PATCH_VERSION: ${{ inputs.PATCH_VERSION || '0' }}
+      SMF_PLUGIN_PATCH_VERSION: ${{ inputs.SMF_PLUGIN_PATCH_VERSION || "0" }}
       
   create_release:
     runs-on: ubuntu-latest

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -20,6 +20,10 @@ on:
         type: string
         required: true
         default: "5"
+      SMF_PLUGIN_PATCH_VERSION:
+        description: "PATCH for SMF plugin"
+        required: true
+        default: ''
 
 jobs:
   macos:
@@ -76,7 +80,7 @@ jobs:
             -DPython_FIND_STRATEGY=LOCATION \
             -DSMF_PLUGIN_MAJOR_VERSION=${{ inputs.MAJOR_VERSION }} \
             -DSMF_PLUGIN_MINOR_VERSION=${{ inputs.MINOR_VERSION }} \
-            -DSMF_PLUGIN_PATCH_VERSION=${{ inputs.PATCH_VERSION }} \
+            -DSMF_PLUGIN_PATCH_VERSION=${{ inputs.SMF_PLUGIN_PATCH_VERSION }} \
             -DSMF_PLUGIN_COMMIT_HASH=0 \
             -DCMAKE_POLICY_DEFAULT_CMP0094=NEW
 

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -22,6 +22,7 @@ on:
         default: "5"
       SMF_PLUGIN_PATCH_VERSION:
         description: "PATCH for SMF plugin"
+        type: string
         required: true
         default: ''
 

--- a/.github/workflows/macos_arm64.yml
+++ b/.github/workflows/macos_arm64.yml
@@ -18,6 +18,10 @@ on:
         type: string
         required: true
         default: '5'
+      SMF_PLUGIN_PATCH_VERSION:
+        description: "PATCH for SMF plugin"
+        required: true
+        default: ''
 
 env:
   # This is the name for the file in releases
@@ -85,7 +89,7 @@ jobs:
             -DPython_EXECUTABLE=${{ env.pythonLocation }}/bin/python \
             -DSMF_PLUGIN_MAJOR_VERSION=${{ inputs.MAJOR_VERSION }} \
             -DSMF_PLUGIN_MINOR_VERSION=${{ inputs.MINOR_VERSION }} \
-            -DSMF_PLUGIN_PATCH_VERSION=${{ inputs.PATCH_VERSION }} \
+            -DSMF_PLUGIN_PATCH_VERSION=${{ inputs.SMF_PLUGIN_PATCH_VERSION }} \
             -DSMF_PLUGIN_COMMIT_HASH=0 \
             -DPython_FIND_STRATEGY=LOCATION
           

--- a/.github/workflows/macos_arm64.yml
+++ b/.github/workflows/macos_arm64.yml
@@ -20,6 +20,7 @@ on:
         default: '5'
       SMF_PLUGIN_PATCH_VERSION:
         description: "PATCH for SMF plugin"
+        type: string
         required: true
         default: ''
 

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -18,6 +18,10 @@ on:
         type: string
         required: true
         default: '5'
+      SMF_PLUGIN_PATCH_VERSION:
+        description: "PATCH for SMF plugin"
+        required: true
+        default: ''
         
 env:
   # This is the name for the file in releases
@@ -60,7 +64,7 @@ jobs:
         run: cmake -GNinja ${{ github.workspace }}/wireshark \
             -DSMF_PLUGIN_MAJOR_VERSION=${{ inputs.MAJOR_VERSION }} \
             -DSMF_PLUGIN_MINOR_VERSION=${{ inputs.MINOR_VERSION }} \
-            -DSMF_PLUGIN_PATCH_VERSION=${{ inputs.PATCH_VERSION }} \
+            -DSMF_PLUGIN_PATCH_VERSION=${{ inputs.SMF_PLUGIN_PATCH_VERSION }} \
             -DSMF_PLUGIN_COMMIT_HASH=0
 
       - name: Build

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -20,6 +20,7 @@ on:
         default: '5'
       SMF_PLUGIN_PATCH_VERSION:
         description: "PATCH for SMF plugin"
+        type: string
         required: true
         default: ''
         

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -18,6 +18,10 @@ on:
         type: string
         required: true
         default: '5'
+      SMF_PLUGIN_PATCH_VERSION:
+        description: "PATCH for SMF plugin"
+        required: true
+        default: ''
 
 env:
   # This is the name for the file in releases

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -89,7 +89,7 @@ jobs:
 
       - name: Cmake
         run: |
-          cmake -DUSE_qt6=ON -DCMAKE_SYSTEM_VERSION="10.0.20348.0" -A x64 ../wireshark -DCMAKE_POLICY_DEFAULT_CMP0094=NEW -DPython3_ROOT_DIR='${{ env.Python3_ROOT_DIR }}' -DPython3_EXECUTABLE='${{ env.Python3_ROOT_DIR }}\python.exe' -DPython3_LIBRARY='${{ env.Python3_ROOT_DIR }}\libs\python380.lib' -DPython3_INCLUDE_DIR='${{ env.Python3_ROOT_DIR }}\Include' -DSMF_PLUGIN_PATCH_VERSION='{{ inputs.SMF_PLUGIN_PATCH_VERSION }}'
+          cmake -DUSE_qt6=ON -DCMAKE_SYSTEM_VERSION="10.0.20348.0" -A x64 ../wireshark -DCMAKE_POLICY_DEFAULT_CMP0094=NEW -DPython3_ROOT_DIR='${{ env.Python3_ROOT_DIR }}' -DPython3_EXECUTABLE='${{ env.Python3_ROOT_DIR }}\python.exe' -DPython3_LIBRARY='${{ env.Python3_ROOT_DIR }}\libs\python380.lib' -DPython3_INCLUDE_DIR='${{ env.Python3_ROOT_DIR }}\Include' -DSMF_PLUGIN_PATCH_VERSION='${{ inputs.SMF_PLUGIN_PATCH_VERSION }}'
         env:
           PLATFORM: x64
           WIRESHARK_BASE_DIR: C:/wireshark-libs

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -88,7 +88,7 @@ jobs:
 
       - name: Cmake
         run: |
-          cmake -DUSE_qt6=ON -DCMAKE_SYSTEM_VERSION="10.0.20348.0" -A x64 ../wireshark -DCMAKE_POLICY_DEFAULT_CMP0094=NEW -DPython3_ROOT_DIR='${{ env.Python3_ROOT_DIR }}' -DPython3_EXECUTABLE='${{ env.Python3_ROOT_DIR }}\python.exe' -DPython3_LIBRARY='${{ env.Python3_ROOT_DIR }}\libs\python380.lib' -DPython3_INCLUDE_DIR='${{ env.Python3_ROOT_DIR }}\Include'
+          cmake -DUSE_qt6=ON -DCMAKE_SYSTEM_VERSION="10.0.20348.0" -A x64 ../wireshark -DCMAKE_POLICY_DEFAULT_CMP0094=NEW -DPython3_ROOT_DIR='${{ env.Python3_ROOT_DIR }}' -DPython3_EXECUTABLE='${{ env.Python3_ROOT_DIR }}\python.exe' -DPython3_LIBRARY='${{ env.Python3_ROOT_DIR }}\libs\python380.lib' -DPython3_INCLUDE_DIR='${{ env.Python3_ROOT_DIR }}\Include' -DSMF_PLUGIN_PATCH_VERSION='{{ inputs.SMF_PLUGIN_PATCH_VERSION }}'
         env:
           PLATFORM: x64
           WIRESHARK_BASE_DIR: C:/wireshark-libs

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -20,6 +20,7 @@ on:
         default: '5'
       SMF_PLUGIN_PATCH_VERSION:
         description: "PATCH for SMF plugin"
+        type: string
         required: true
         default: ''
 


### PR DESCRIPTION
Update the windows workflow to include the SMF_PLUGIN_PATCH_VERION in VERSIONFILE.  This is now a mandatory input on build_plugin, so developers can set what they want, and on create_release.

I suspect however that it still does not work on Linux or MacOS.